### PR TITLE
Additions to Farmland

### DIFF
--- a/src/MiNET/MiNET/Blocks/Farmland.cs
+++ b/src/MiNET/MiNET/Blocks/Farmland.cs
@@ -5,5 +5,10 @@
 		internal Farmland() : base(60)
 		{
 		}
+
+     	public override ItemStack GetDrops()
+		{
+		return new ItemStack(3, 1); // Drop dirt block
+		}
 	}
 }

--- a/src/MiNET/MiNET/Blocks/Farmland.cs
+++ b/src/MiNET/MiNET/Blocks/Farmland.cs
@@ -1,4 +1,6 @@
-﻿namespace MiNET.Blocks
+﻿using MiNET.Items;
+
+namespace MiNET.Blocks
 {
 	internal class Farmland : Block
 	{

--- a/src/MiNET/MiNET/Items/ItemHoe.cs
+++ b/src/MiNET/MiNET/Items/ItemHoe.cs
@@ -13,7 +13,7 @@ namespace MiNET.Items
 		public override void UseItem(Level world, Player player, BlockCoordinates blockCoordinates, BlockFace face, Vector3 faceCoords)
 		{
 			Block tile = world.GetBlock(blockCoordinates);
-			if (tile.Id == 2 || tile.Id == 3)
+			if (tile.Id == 2 || tile.Id == 3 || tile.Id == 198)
 			{
 				Farmland farm = new Farmland
 				{


### PR DESCRIPTION
Small changes to Farmland. Planting stuff comes when I can figure out how to do something like world.setBlock(blockCoordinates+1) but idk if that's a thing.

Anyway this adds:
•Farmland now drops dirt
•You can now hoe Grass Path (Pressed Dirt) to get Farmland.