### PR TITLE
Made Level::SpawnPoint and Player::SpawnPosition a PlayerLocation.

### DIFF
--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -635,7 +635,7 @@ namespace MiNET
 			SpawnLevel(toLevel, toLevel.SpawnPoint);
 		}
 
-		public void SpawnLevel(Level toLevel, PlayerLocation spawnPoint)
+		public virtual void SpawnLevel(Level toLevel, PlayerLocation spawnPoint)
 		{
 			NoAi = true;
 			SendSetEntityData();

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -40,7 +40,7 @@ namespace MiNET
 		private Inventory _openInventory;
 		public PlayerInventory Inventory { get; private set; }
 
-		public BlockCoordinates SpawnPosition { get; set; }
+		public PlayerLocation SpawnPosition { get; set; }
 
 		public GameMode GameMode { get; set; }
 		public bool IsConnected { get; set; }
@@ -635,7 +635,7 @@ namespace MiNET
 			SpawnLevel(toLevel, toLevel.SpawnPoint);
 		}
 
-		public void SpawnLevel(Level toLevel, BlockCoordinates spawnPoint)
+		public void SpawnLevel(Level toLevel, PlayerLocation spawnPoint)
 		{
 			NoAi = true;
 			SendSetEntityData();

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -683,15 +683,7 @@ namespace MiNET
 			ThreadPool.QueueUserWorkItem(state => ForcedSendChunksForKnownPosition());
 
 			// send teleport to spawn
-			SetPosition(new PlayerLocation
-			{
-				X = spawnPoint.X,
-				Y = spawnPoint.Y,
-				Z = spawnPoint.Z,
-				Yaw = 91,
-				Pitch = 28,
-				HeadYaw = 91,
-			});
+			SetPosition(spawnPoint);
 
 			NoAi = false;
 			SendSetEntityData();

--- a/src/MiNET/MiNET/Utils/PlayerLocation.cs
+++ b/src/MiNET/MiNET/Utils/PlayerLocation.cs
@@ -26,6 +26,8 @@ namespace MiNET.Utils
 			Z = z;
 		}
 
+        public PlayerLocation(Vector3 vector) : this(vector.X, vector.Y, vector.Z) { }
+
 		public BlockCoordinates GetCoordinates3D()
 		{
 			return new BlockCoordinates((int) X, (int) Y, (int) Z);

--- a/src/MiNET/MiNET/Worlds/Level.cs
+++ b/src/MiNET/MiNET/Worlds/Level.cs
@@ -36,7 +36,7 @@ namespace MiNET.Worlds
 		private int _worldDayCycleTime = 19200;
 		//private int _worldDayCycleTime = 14400;
 
-		public BlockCoordinates SpawnPoint { get; set; }
+		public PlayerLocation SpawnPoint { get; set; }
 		public ConcurrentDictionary<long, Player> Players { get; private set; } //TODO: Need to protect this, not threadsafe
 		public List<Entity> Entities { get; private set; } //TODO: Need to protect this, not threadsafe
 		public List<BlockEntity> BlockEntities { get; private set; } //TODO: Need to protect this, not threadsafe
@@ -63,7 +63,7 @@ namespace MiNET.Worlds
 
 			EntityManager = new EntityManager();
 			InventoryManager = new InventoryManager(this);
-			SpawnPoint = new BlockCoordinates(50, 10, 50);
+			SpawnPoint = new PlayerLocation(50, 4000, 50);
 			Players = new ConcurrentDictionary<long, Player>();
 			Entities = new List<Entity>();
 			BlockEntities = new List<BlockEntity>();
@@ -108,7 +108,7 @@ namespace MiNET.Worlds
 			IsWorldTimeStarted = true;
 			_worldProvider.Initialize();
 
-			SpawnPoint = _worldProvider.GetSpawnPoint();
+			SpawnPoint = new PlayerLocation(_worldProvider.GetSpawnPoint());
 			CurrentWorldTime = _worldProvider.GetTime();
 
 			if (_worldProvider.IsCaching)
@@ -119,7 +119,7 @@ namespace MiNET.Worlds
 				chunkLoading.Start();
 				// Pre-cache chunks for spawn coordinates
 				int i = 0;
-				foreach (var chunk in GenerateChunks(new ChunkCoordinates(SpawnPoint.X >> 4, SpawnPoint.Z >> 4), new Dictionary<Tuple<int, int>, McpeBatch>()))
+				foreach (var chunk in GenerateChunks(new ChunkCoordinates((int) SpawnPoint.X >> 4, (int) SpawnPoint.Z >> 4), new Dictionary<Tuple<int, int>, McpeBatch>()))
 				{
 					//chunk.PutPool();
 					i++;
@@ -687,11 +687,7 @@ namespace MiNET.Worlds
 
 		public void SetBlock(Block block, bool broadcast = true, bool applyPhysics = true)
 		{
-			BlockCoordinates spawn = SpawnPoint;
-			//if (block.Coordinates.DistanceTo(spawn) < 30)
-			//{
-			//	return;
-			//}
+			PlayerLocation spawn = SpawnPoint;
 
 			ChunkColumn chunk = _worldProvider.GenerateChunkColumn(new ChunkCoordinates(block.Coordinates.X >> 4, block.Coordinates.Z >> 4));
 			chunk.SetBlock(block.Coordinates.X & 0x0f, block.Coordinates.Y & 0x7f, block.Coordinates.Z & 0x0f, block.Id);

--- a/src/MiNET/TestPlugin/CoreCommands.cs
+++ b/src/MiNET/TestPlugin/CoreCommands.cs
@@ -67,9 +67,9 @@ namespace TestPlugin
 				generator = 1,
 				gamemode = gameMode,
 				entityId = player.EntityId,
-				spawnX = player.Level.SpawnPoint.X,
-				spawnY = player.Level.SpawnPoint.Y,
-				spawnZ = player.Level.SpawnPoint.Z,
+				spawnX = (int) player.Level.SpawnPoint.X,
+				spawnY = (int) player.Level.SpawnPoint.Y,
+				spawnZ = (int) player.Level.SpawnPoint.Z,
 				x = player.KnownPosition.X,
 				y = player.KnownPosition.Y,
 				z = player.KnownPosition.Z

--- a/src/MiNET/TestPlugin/NiceLobby/NiceLobbyPlugin.cs
+++ b/src/MiNET/TestPlugin/NiceLobby/NiceLobbyPlugin.cs
@@ -57,10 +57,10 @@ namespace TestPlugin.NiceLobby
 				Level level = Context.LevelManager.Levels.First();
 				Random random = level.Random;
 
-				BlockCoordinates point1 = level.SpawnPoint;
-				BlockCoordinates point2 = level.SpawnPoint;
+				PlayerLocation point1 = level.SpawnPoint;
+                PlayerLocation point2 = level.SpawnPoint;
 				point2.X += 10;
-				BlockCoordinates point3 = level.SpawnPoint;
+                PlayerLocation point3 = level.SpawnPoint;
 				point3.X -= 10;
 
 				if (Math.Abs(m - 3) < 0.1)
@@ -126,7 +126,7 @@ namespace TestPlugin.NiceLobby
 			if (m > 3.8) m = -5;
 		}
 
-		private void GenerateParticles(Random random, Level level, BlockCoordinates point, float yoffset, Vector3 multiplier, double d)
+		private void GenerateParticles(Random random, Level level, PlayerLocation point, float yoffset, Vector3 multiplier, double d)
 		{
 			float vx = (float) random.NextDouble();
 			vx *= random.Next(2) == 0 ? 1 : -1;


### PR DESCRIPTION
I think that it's either an error in the protocol or a misuse on MiNET that the spawn position is saved with integers and doesn't include the yaw.

This becomes problematic with the SpawnLevel method. It even creates a new PlayerLocation in its SetPosition call to compensate.