### PR TITLE
Enable support for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ mono:
   - weekly
   - beta
   - alpha
+script: xbuild /p:TargetFrameworkVersion="v4.5" src/MiNET/MiNET.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: csharp
+solution: src/MiNET/MiNET.sln
+mono:
+  - latest
+  - weekly
+  - beta
+  - alpha


### PR DESCRIPTION
These will build with Mono instead of the default .NET framework.