### PR TITLE
Usernames may contain spaces (e.g. Xbox users)

### DIFF
--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -535,7 +535,7 @@ namespace MiNET
 			//	}
 			//}
 
-			if (message.username == null || message.username.Trim().Length == 0 || !Regex.IsMatch(message.username, "^[A-Za-z0-9_-]{3,16}$"))
+			if (message.username == null || message.username.Trim().Length == 0 || !Regex.IsMatch(message.username, "^[A-Za-z0-9_ -]{3,16}$"))
 			{
 				Disconnect("Invalid username.");
 				return;


### PR DESCRIPTION
The current username checking regex implementation doesn't allow players with spaces in their names to join a server. This character addition in the commit fixes this issue.