### PR TITLE
Change Item's MaxStackSIze to a byte

### DIFF
--- a/src/MiNET/MiNET/Items/Item.cs
+++ b/src/MiNET/MiNET/Items/Item.cs
@@ -16,7 +16,7 @@ namespace MiNET.Items
 		public short Metadata { get; set; }
 		public ItemMaterial ItemMaterial { get; set; } = ItemMaterial.None;
 		public ItemType ItemType { get; set; } = ItemType.Item;
-		public int MaxStackSize { get; set; } = 64;
+		public byte MaxStackSize { get; set; } = 64;
 		public bool IsStackable => MaxStackSize > 1;
 		public int Durability { get; set; }
 		public int FuelEfficiency { get; set; }


### PR DESCRIPTION
...because every function involving 'stackSize' or 'count' is a byte, so it wouldn't have sense to have it as a integer.