### PR TITLE
Move Silent, HideNameTag, NoAi up to Entity.

### DIFF
--- a/src/MiNET/MiNET/Entities/Entity.cs
+++ b/src/MiNET/MiNET/Entities/Entity.cs
@@ -36,6 +36,10 @@ namespace MiNET.Entities
 		public double Gravity { get; set; }
 		public int Data { get; set; }
 
+		public bool Silent { get; set; }
+		public bool HideNameTag { get; set; }
+		public bool NoAi { get; set; }
+
 		public Entity(int entityTypeId, Level level)
 		{
 			Height = 1;
@@ -58,9 +62,9 @@ namespace MiNET.Entities
 			//metadata[0] = new MetadataByte((byte) (HealthManager.IsOnFire ? 1 : 0));
 			metadata[1] = new MetadataShort(HealthManager.Air);
 			metadata[2] = new MetadataString(NameTag ?? string.Empty);
-			metadata[3] = new MetadataByte(1);
-			metadata[4] = new MetadataByte(0);
-			metadata[15] = new MetadataByte(0);
+			metadata[3] = new MetadataByte(HideNameTag);
+			metadata[4] = new MetadataByte(Silent);
+			metadata[15] = new MetadataByte(NoAi);
 			//metadata[16] = new MetadataByte(0);
 
 			return metadata;

--- a/src/MiNET/MiNET/Entities/Entity.cs
+++ b/src/MiNET/MiNET/Entities/Entity.cs
@@ -62,7 +62,7 @@ namespace MiNET.Entities
 			//metadata[0] = new MetadataByte((byte) (HealthManager.IsOnFire ? 1 : 0));
 			metadata[1] = new MetadataShort(HealthManager.Air);
 			metadata[2] = new MetadataString(NameTag ?? string.Empty);
-			metadata[3] = new MetadataByte(HideNameTag);
+			metadata[3] = new MetadataByte(!HideNameTag);
 			metadata[4] = new MetadataByte(Silent);
 			metadata[15] = new MetadataByte(NoAi);
 			//metadata[16] = new MetadataByte(0);

--- a/src/MiNET/MiNET/Entities/PlayerMob.cs
+++ b/src/MiNET/MiNET/Entities/PlayerMob.cs
@@ -41,15 +41,9 @@ namespace MiNET.Entities
 
 		public override MetadataDictionary GetMetadata()
 		{
-			MetadataDictionary metadata = new MetadataDictionary();
-			metadata[0] = new MetadataByte((byte) (HealthManager.IsOnFire ? 1 : 0));
-			metadata[1] = new MetadataShort(HealthManager.Air);
-			metadata[2] = new MetadataString(NameTag ?? Name);
-			metadata[3] = new MetadataByte(!HideNameTag);
-			metadata[4] = new MetadataByte(Silent);
+			MetadataDictionary metadata = base.GetMetadata();
 			metadata[7] = new MetadataInt(0); // Potion Color
 			metadata[8] = new MetadataByte(0); // Potion Ambient
-			metadata[15] = new MetadataByte(NoAi);
 			metadata[16] = new MetadataByte(0); // Player flags
 			//metadata[17] = new MetadataIntCoordinates(0, 0, 0);
 

--- a/src/MiNET/MiNET/Entities/World/ItemEntity.cs
+++ b/src/MiNET/MiNET/Entities/World/ItemEntity.cs
@@ -21,13 +21,7 @@ namespace MiNET.Entities.World
 
 			PickupDelay = 10;
 			TimeToLive = 6000;
-		}
-
-		public override MetadataDictionary GetMetadata()
-		{
-			MetadataDictionary metadata = base.GetMetadata();
-			metadata[15] = new MetadataByte(1);
-			return metadata;
+			NoAi = true;
 		}
 
 		public Item GetItemStack()

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -2157,15 +2157,9 @@ namespace MiNET
 
 		public override MetadataDictionary GetMetadata()
 		{
-			MetadataDictionary metadata = new MetadataDictionary();
-			metadata[0] = new MetadataByte(GetDataValue());
-			metadata[1] = new MetadataShort(HealthManager.Air);
-			metadata[2] = new MetadataString(NameTag ?? Username);
-			metadata[3] = new MetadataByte(!HideNameTag);
-			metadata[4] = new MetadataByte(Silent);
+			MetadataDictionary metadata = base.GetMetadata();
 			metadata[7] = new MetadataInt(0); // Potion Color
 			metadata[8] = new MetadataByte(0); // Potion Ambient
-			metadata[15] = new MetadataByte(NoAi);
 			metadata[16] = new MetadataByte(0); // Player flags
 			metadata[17] = new MetadataIntCoordinates(0, 0, 0);
 

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -56,9 +56,6 @@ namespace MiNET
 		public UUID ClientUuid { get; set; }
 
 		public Skin Skin { get; set; }
-		public bool Silent { get; set; }
-		public bool HideNameTag { get; set; }
-		public bool NoAi { get; set; }
 
 		public float EnchantingLevel { get; set; } = 0f;
 		public float Experience { get; set; } = 0f;


### PR DESCRIPTION
As the title implies. These properties can be used by all entities, so makes sense to be in Entity rather than Player.