### PR TITLE
Fix special case with signs and encoded unicode characters.

### DIFF
--- a/src/MiNET/MiNET/Worlds/AnvilWorldProvider.cs
+++ b/src/MiNET/MiNET/Worlds/AnvilWorldProvider.cs
@@ -421,7 +421,7 @@ namespace MiNET.Worlds
 		private static void CleanSignText(NbtCompound blockEntityTag, string tagName)
 		{
 			var text = blockEntityTag[tagName].StringValue;
-			var replace = _regex.Replace(text, "$3");
+			var replace = Regex.Unescape(_regex.Replace(text, "$3"));
 			blockEntityTag[tagName] = new NbtString(tagName, replace);
 		}
 


### PR DESCRIPTION
Unescape unicode strings inside signs. (e.g. \u0027 becomes ')