### PR TITLE
Fix server.conf under Linux

### DIFF
--- a/src/MiNET/MiNET.Service/server.conf
+++ b/src/MiNET/MiNET.Service/server.conf
@@ -49,8 +49,8 @@ PCWorldFolder=D:\Development\Worlds\TopixMedia Lobby
 #PCWorldFolder=D:\Development\Repos\MapsPE\sg.station
 
 #EnableSecurity=true
-#PluginDirectory=..\..\..\TestPlugin\bin\Release;
-PluginDirectory=..\..\..\TestPlugin\bin\Debug;
+#PluginDirectory=../../../TestPlugin/bin/Release;
+PluginDirectory=../../../TestPlugin/bin/Debug;
 
 #PluginDisabled=true
 #NiceLobby.Enabled=false


### PR DESCRIPTION
Linux doesn't like backslashes, but Windows can work with forward slashes.
Tested with Mono 4.4.0.148 under Arch Linux and with Windows 10.