### PR TITLE
Significantly improve packet event handling performance

### DIFF
--- a/src/MiNET/MiNET.Test/BenchmarkEventHandlerGenerators.cs
+++ b/src/MiNET/MiNET.Test/BenchmarkEventHandlerGenerators.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MiNET.Net;
+using MiNET.Plugins;
+using MiNET.Plugins.Attributes;
+
+namespace MiNET
+{
+    [TestClass]
+    public class BenchmarkEventHandlerGenerators
+    {
+        private const int Iterations = 250000;
+
+        [TestMethod]
+        public void BenchmarkReflectionEventHandlerGenerator()
+        {
+            Benchmark(() => new ReflectionPackageHandlerGenerator());
+        }
+
+        [TestMethod]
+        public void BenchmarkEmittedEventHandlerGenerator()
+        {
+            Benchmark(() => new EmittedPackageHandlerGenerator());
+        }
+
+        private static void Benchmark(Func<IPackageEventHandlerGenerator> supplier)
+        {
+            var instance = new DummyHandler();
+            var stopwatch = new Stopwatch();
+            var package = new McpeText();
+            var generator = supplier();
+
+            MethodInfo site = instance.GetType().GetMethod("Handle", new[] { typeof(McpeText) });
+            IPackageEventHandler handler = generator.Generate(instance, site, typeof(McpeText));
+
+            // warm up
+            for (int i = 0; i < Iterations / 10; i++)
+            {
+                handler.Handle(package, null);
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            stopwatch.Start();
+            for (int i = 0; i < Iterations; i++)
+            {
+                handler.Handle(package, null);
+            }
+            stopwatch.Stop();
+            Trace.WriteLine(string.Format("Iterations: {0}", Iterations));
+            Trace.WriteLine(string.Format("{0}: {1} ticks", generator.GetType().FullName, stopwatch.Elapsed.Ticks));
+        }
+
+        public class DummyHandler
+        {
+            [PacketHandler]
+            public void Handle(McpeText package)
+            {
+
+            }
+        }
+    }
+}

--- a/src/MiNET/MiNET.Test/MiNET.Test.csproj
+++ b/src/MiNET/MiNET.Test/MiNET.Test.csproj
@@ -69,7 +69,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -78,6 +80,7 @@
     <Compile Include="MinetAnvilTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MinetServerTest.cs" />
+    <Compile Include="BenchmarkEventHandlerGenerators.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiNET\MiNET.csproj">

--- a/src/MiNET/MiNET/MiNET.csproj
+++ b/src/MiNET/MiNET/MiNET.csproj
@@ -452,6 +452,7 @@
     <Compile Include="PlayerFactory.cs" />
     <Compile Include="PlayerNetworkSession.cs" />
     <Compile Include="Plugins\Attributes\AuthorizeAttribute.cs" />
+    <Compile Include="Plugins\IPackageEventHandlerGenerator.cs" />
     <Compile Include="Plugins\IStartup.cs" />
     <Compile Include="Plugins\Plugin.cs" />
     <Compile Include="Plugins\Attributes\CommandAttribute.cs" />

--- a/src/MiNET/MiNET/Plugins/IPackageEventHandlerGenerator.cs
+++ b/src/MiNET/MiNET/Plugins/IPackageEventHandlerGenerator.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using MiNET.Net;
+
+namespace MiNET.Plugins
+{
+    public interface IPackageEventHandler
+    {
+        Package Handle(Package package, Player player);
+    }
+
+    public interface IPackageEventHandlerGenerator
+    {
+        IPackageEventHandler Generate(object plugin, MethodInfo method, Type type);
+    }
+
+    public class ReflectionPackageHandlerGenerator : IPackageEventHandlerGenerator
+    {
+        private sealed class ReflectionPackageEventHandler : IPackageEventHandler
+        {
+            private readonly Func<Package, Player, Package> @delegate;
+
+            public ReflectionPackageEventHandler(Func<Package, Player, Package> @delegate)
+            {
+                this.@delegate = @delegate;
+            }
+
+            public Package Handle(Package package, Player player)
+            {
+                return @delegate.Invoke(package, player);
+            }
+        }
+
+        public IPackageEventHandler Generate(object plugin, MethodInfo method, Type type)
+        {
+            if (method.IsStatic)
+            {
+                return new ReflectionPackageEventHandler((package, player) =>
+                {
+                    method.Invoke(null, new object[] { package, player });
+                    return package;
+                });
+            }
+
+            if (method.GetParameters().Length == 2)
+            {
+                return new ReflectionPackageEventHandler((package, player) => (Package)method.Invoke(plugin, new object[] { package, player }));
+            }
+            return new ReflectionPackageEventHandler((package, player) => (Package)method.Invoke(plugin, new object[] { package }));
+        }
+    }
+
+    public class EmittedPackageHandlerGenerator : IPackageEventHandlerGenerator
+    {
+        private static readonly TypeAttributes SharedExecutorTypeAttributes = TypeAttributes.Public |
+                                                                        TypeAttributes.AutoClass |
+                                                                        TypeAttributes.AnsiClass |
+                                                                        TypeAttributes.BeforeFieldInit;
+
+        private static readonly MethodAttributes SharedExecutorConstructorAttributes = MethodAttributes.Public |
+                                                                                       MethodAttributes.HideBySig |
+                                                                                       MethodAttributes.RTSpecialName |
+                                                                                       MethodAttributes.SpecialName;
+
+        private static readonly MethodAttributes SharedExecutorMethodAttributes = MethodAttributes.Public |
+                                                                                        MethodAttributes.HideBySig |
+                                                                                        MethodAttributes.NewSlot |
+                                                                                        MethodAttributes.Virtual |
+                                                                                        MethodAttributes.Final;
+
+        private static readonly FieldAttributes InstanceExecutorFieldAttributes = FieldAttributes.Private |
+                                                                                  FieldAttributes.InitOnly;
+
+        private static readonly Type[] ExecutorInterfaces = { typeof(IPackageEventHandler) };
+
+        private static readonly ConstructorInfo ObjectConstructorInfo = typeof(object).GetConstructor(new Type[0]);
+
+        public IPackageEventHandler Generate(object plugin, MethodInfo method, Type packageType)
+        {
+            if (!method.DeclaringType?.IsVisible ?? true)
+            {
+                // TODO: Figure out more appropriate method of handling.
+                return new NopPackageEventHandler();
+            }
+
+            string name = Guid.NewGuid().ToString().Replace("-", "");
+
+            AssemblyName assemblyName = new AssemblyName(name);
+            AssemblyBuilder assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(name);
+            TypeBuilder typeBuilder = moduleBuilder.DefineType(string.Format("MiNET.Plugins.Executor_{0}", name), SharedExecutorTypeAttributes, typeof(object), ExecutorInterfaces);
+
+            object[] constructorArguments;
+            if (method.IsStatic)
+            {
+                ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(SharedExecutorConstructorAttributes, CallingConventions.Standard, Type.EmptyTypes);
+                constructorBuilder.SetImplementationFlags(MethodImplAttributes.Managed);
+                ILGenerator generator = constructorBuilder.GetILGenerator();
+                generator.Emit(OpCodes.Ldarg_0);
+                generator.Emit(OpCodes.Call, ObjectConstructorInfo);
+                generator.Emit(OpCodes.Ret);
+
+                MethodBuilder methodBuilder = typeBuilder.DefineMethod("Handle", SharedExecutorMethodAttributes, CallingConventions.Standard, typeof(Package), new[] { typeof(Package), typeof(Player) });
+                methodBuilder.SetImplementationFlags(MethodImplAttributes.Managed);
+                generator = methodBuilder.GetILGenerator();
+                generator.Emit(OpCodes.Ldarg_1);
+                generator.Emit(OpCodes.Isinst, packageType);
+                generator.Emit(OpCodes.Ldarg_2);
+                generator.Emit(OpCodes.Call, method);
+                generator.Emit(OpCodes.Ldarg_1);
+                generator.Emit(OpCodes.Ret);
+
+                constructorArguments = new object[0];
+            }
+            else
+            {
+                FieldBuilder fieldBuilder = typeBuilder.DefineField("_delegate", plugin.GetType(), InstanceExecutorFieldAttributes);
+                ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(SharedExecutorConstructorAttributes, CallingConventions.Standard, new[] { plugin.GetType() });
+                constructorBuilder.SetImplementationFlags(MethodImplAttributes.Managed);
+                ILGenerator generator = constructorBuilder.GetILGenerator();
+                generator.Emit(OpCodes.Ldarg_0);
+                generator.Emit(OpCodes.Call, ObjectConstructorInfo);
+                generator.Emit(OpCodes.Ldarg_0);
+                generator.Emit(OpCodes.Ldarg_1);
+                generator.Emit(OpCodes.Stfld, fieldBuilder);
+                generator.Emit(OpCodes.Ret);
+
+                MethodBuilder methodBuilder = typeBuilder.DefineMethod("Handle", SharedExecutorMethodAttributes, CallingConventions.HasThis, typeof(Package), new[] { typeof(Package), typeof(Player) });
+                methodBuilder.SetImplementationFlags(MethodImplAttributes.Managed);
+                generator = methodBuilder.GetILGenerator();
+
+                generator.Emit(OpCodes.Ldarg_0);
+                generator.Emit(OpCodes.Ldfld, fieldBuilder);
+                generator.Emit(OpCodes.Ldarg_1);
+                generator.Emit(OpCodes.Isinst, packageType);
+                if (method.GetParameters().Length == 2)
+                {
+                    generator.Emit(OpCodes.Ldarg_2);
+                }
+                generator.Emit(OpCodes.Callvirt, method);
+                if (method.ReturnType == typeof(void))
+                {
+                    generator.Emit(OpCodes.Ldarg_1);
+                }
+                generator.Emit(OpCodes.Ret);
+
+                constructorArguments = new[] { plugin };
+            }
+
+            Type result = typeBuilder.CreateType();
+            return (IPackageEventHandler)Activator.CreateInstance(result, constructorArguments);
+        }
+    }
+
+    internal class NopPackageEventHandler : IPackageEventHandler
+    {
+        public Package Handle(Package package, Player player)
+        {
+            return package;
+        }
+    }
+}

--- a/src/MiNET/MiNET/Plugins/PluginManager.cs
+++ b/src/MiNET/MiNET/Plugins/PluginManager.cs
@@ -15,539 +15,551 @@ using MiNET.Utils;
 
 namespace MiNET.Plugins
 {
-	public class PluginManager
-	{
-		private static readonly ILog Log = LogManager.GetLogger(typeof (MiNetServer));
+    public class PluginManager
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(MiNetServer));
 
-		private readonly List<object> _plugins = new List<object>();
-		private readonly Dictionary<MethodInfo, PacketHandlerAttribute> _packetHandlerDictionary = new Dictionary<MethodInfo, PacketHandlerAttribute>();
-		private readonly Dictionary<MethodInfo, PacketHandlerAttribute> _packetSendHandlerDictionary = new Dictionary<MethodInfo, PacketHandlerAttribute>();
-		private readonly Dictionary<MethodInfo, CommandAttribute> _pluginCommands = new Dictionary<MethodInfo, CommandAttribute>();
+        private readonly List<object> _plugins = new List<object>();
+        private readonly Dictionary<MethodInfo, CommandAttribute> _pluginCommands = new Dictionary<MethodInfo, CommandAttribute>();
 
-		public List<object> Plugins
-		{
-			get { return _plugins; }
-		}
+        private readonly IDictionary<object, ISet<IPackageEventHandler>> _registrantHandlerMapping = new Dictionary<object, ISet<IPackageEventHandler>>();
+        private readonly IDictionary<Type, ISet<IPackageEventHandler>> _packageReceiveHandlers = new Dictionary<Type, ISet<IPackageEventHandler>>();
+        private readonly IDictionary<Type, ISet<IPackageEventHandler>> _packageSendHandlers = new Dictionary<Type, ISet<IPackageEventHandler>>();
+        private readonly IPackageEventHandlerGenerator _packageEventHandlerGenerator = new EmittedPackageHandlerGenerator();
 
-		public List<CommandAttribute> PluginCommands
-		{
-			get { return _pluginCommands.Values.ToList(); }
-		}
+        public List<object> Plugins
+        {
+            get { return _plugins; }
+        }
 
-		private string _currentPath = null;
+        public List<CommandAttribute> PluginCommands
+        {
+            get { return _pluginCommands.Values.ToList(); }
+        }
 
-		internal void LoadPlugins()
-		{
-			if (Config.GetProperty("PluginDisabled", false)) return;
+        private string _currentPath = null;
 
-			// Default it is the directory we are executing, and below.
-			string pluginDirectoryPaths = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-			pluginDirectoryPaths = Config.GetProperty("PluginDirectory", pluginDirectoryPaths);
-			//HACK: Make it possible to define multiple PATH;PATH;PATH
+        internal void LoadPlugins()
+        {
+            if (Config.GetProperty("PluginDisabled", false)) return;
 
-			foreach (string dirPath in pluginDirectoryPaths.Split(new char[] {';'}, StringSplitOptions.RemoveEmptyEntries))
-			{
-				if (dirPath == null) continue;
+            // Default it is the directory we are executing, and below.
+            string pluginDirectoryPaths = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+            pluginDirectoryPaths = Config.GetProperty("PluginDirectory", pluginDirectoryPaths);
+            //HACK: Make it possible to define multiple PATH;PATH;PATH
 
-				string pluginDirectory = Path.GetFullPath(dirPath);
+            foreach (string dirPath in pluginDirectoryPaths.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (dirPath == null) continue;
 
-				_currentPath = pluginDirectory;
+                string pluginDirectory = Path.GetFullPath(dirPath);
 
-				AppDomain currentDomain = AppDomain.CurrentDomain;
-				currentDomain.AssemblyResolve += MyResolveEventHandler;
+                _currentPath = pluginDirectory;
 
-				List<string> pluginPaths = new List<string>();
-				pluginPaths.AddRange(Directory.GetFiles(pluginDirectory, "*.dll", SearchOption.AllDirectories));
-				pluginPaths.AddRange(Directory.GetFiles(pluginDirectory, "*.exe", SearchOption.AllDirectories));
+                AppDomain currentDomain = AppDomain.CurrentDomain;
+                currentDomain.AssemblyResolve += MyResolveEventHandler;
 
-				foreach (string pluginPath in pluginPaths)
-				{
-					Assembly newAssembly = Assembly.LoadFile(pluginPath);
+                List<string> pluginPaths = new List<string>();
+                pluginPaths.AddRange(Directory.GetFiles(pluginDirectory, "*.dll", SearchOption.AllDirectories));
+                pluginPaths.AddRange(Directory.GetFiles(pluginDirectory, "*.exe", SearchOption.AllDirectories));
 
-					Type[] types = newAssembly.GetExportedTypes();
-					foreach (Type type in types)
-					{
-						try
-						{
-							// If no PluginAttribute and does not implement IPlugin interface, not a valid plugin
-							if (!type.IsDefined(typeof (PluginAttribute), true) && !typeof (IPlugin).IsAssignableFrom(type)) continue;
-							if (type.IsDefined(typeof (PluginAttribute), true))
-							{
-								PluginAttribute pluginAttribute = Attribute.GetCustomAttribute(type, typeof (PluginAttribute), true) as PluginAttribute;
-								if (pluginAttribute != null)
-								{
-									if (!Config.GetProperty(pluginAttribute.PluginName + ".Enabled", true)) continue;
-								}
-							}
-							var ctor = type.GetConstructor(Type.EmptyTypes);
-							if (ctor != null)
-							{
-								var plugin = ctor.Invoke(null);
-								_plugins.Add(plugin);
-								LoadCommands(type);
-								LoadPacketHandlers(type);
-							}
-						}
-						catch (Exception ex)
-						{
-							Log.WarnFormat("Failed loading plugin type {0} as a plugin.", type);
-							Log.Debug("Plugin loader caught exception, but is moving on.", ex);
-						}
-					}
-				}
-			}
-		}
+                foreach (string pluginPath in pluginPaths)
+                {
+                    Assembly newAssembly = Assembly.LoadFile(pluginPath);
 
-		private Assembly MyResolveEventHandler(object sender, ResolveEventArgs args)
-		{
-			if (_currentPath == null) return null;
-
-			try
-			{
-				AssemblyName name = new AssemblyName(args.Name);
-				string assemblyPath = _currentPath + "\\" + name.Name + ".dll";
-				return Assembly.LoadFile(assemblyPath);
-			}
-			catch (Exception)
-			{
-				try
-				{
-					AssemblyName name = new AssemblyName(args.Name);
-					string assemblyPath = _currentPath + "\\" + name.Name + ".exe";
-					return Assembly.LoadFile(assemblyPath);
-				}
-				catch (Exception)
-				{
-					return Assembly.LoadFile(args.Name + ".dll");
-				}
-			}
-		}
-
-		public void LoadCommands(object instance)
-		{
-			if (!_plugins.Contains(instance)) _plugins.Add(instance);
-			LoadCommands(instance.GetType());
-		}
-
-		private void LoadCommands(Type type)
-		{
-			var methods = type.GetMethods();
-			foreach (MethodInfo method in methods)
-			{
-				CommandAttribute commandAttribute = Attribute.GetCustomAttribute(method, typeof (CommandAttribute), false) as CommandAttribute;
-				if (commandAttribute == null) continue;
-
-				if (string.IsNullOrEmpty(commandAttribute.Command))
-				{
-					commandAttribute.Command = method.Name;
-				}
-
-				StringBuilder sb = new StringBuilder();
-				sb.Append("/");
-				sb.Append(commandAttribute.Command);
-				var parameters = method.GetParameters();
-				if (parameters.Length > 0) sb.Append(" ");
-				bool isFirstParam = true;
-				foreach (var parameter in parameters)
-				{
-					if (isFirstParam && parameter.ParameterType == typeof (Player))
-					{
-						continue;
-					}
-					isFirstParam = false;
-
-					sb.AppendFormat("<{0}> ", parameter.Name);
-				}
-				commandAttribute.Usage = sb.ToString().Trim();
-
-				DescriptionAttribute descriptionAttribute = Attribute.GetCustomAttribute(method, typeof (DescriptionAttribute), false) as DescriptionAttribute;
-				if (descriptionAttribute != null) commandAttribute.Description = descriptionAttribute.Description;
-
-				_pluginCommands.Add(method, commandAttribute);
-				Log.Debug($"Loaded command {commandAttribute.Usage}");
-			}
-		}
-
-		public void UnloadCommands(object instance)
-		{
-			if (!_plugins.Contains(instance)) return;
-			_plugins.Remove(instance);
-
-			var methods = _pluginCommands.Keys.Where(info => info.DeclaringType == instance.GetType()).ToArray();
-			foreach (var method in methods)
-			{
-				_pluginCommands.Remove(method);
-			}
-		}
-
-		public void LoadPacketHandlers(object instance)
-		{
-			if (!_plugins.Contains(instance)) _plugins.Add(instance);
-			LoadPacketHandlers(instance.GetType());
-		}
-
-		private void LoadPacketHandlers(Type type)
-		{
-			var methods = type.GetMethods();
-			foreach (MethodInfo method in methods)
-			{
-				{
-					PacketHandlerAttribute packetHandlerAttribute = Attribute.GetCustomAttribute(method, typeof (PacketHandlerAttribute), false) as PacketHandlerAttribute;
-					if (packetHandlerAttribute != null)
-					{
-						ParameterInfo[] parameters = method.GetParameters();
-						if (parameters.Length < 1) continue;
-						if (!typeof(Package).IsAssignableFrom(parameters[0].ParameterType)) continue;
-						if (packetHandlerAttribute.PacketType == null) packetHandlerAttribute.PacketType = parameters[0].ParameterType;
-
-						if (Attribute.GetCustomAttribute(method, typeof (SendAttribute), false) != null)
-						{
-							_packetSendHandlerDictionary.Add(method, packetHandlerAttribute);
-						}
-						else
-						{
-							_packetHandlerDictionary.Add(method, packetHandlerAttribute);
-						}
-					}
-				}
-			}
-		}
-
-		public void UnloadPacketHandlers(object instance)
-		{
-			//if (!_plugins.Contains(instance)) return;
-			//_plugins.Remove(instance);
-
-			var methods = _packetHandlerDictionary.Keys.Where(info => info.DeclaringType == instance.GetType()).ToArray();
-			foreach (var method in methods)
-			{
-				_packetHandlerDictionary.Remove(method);
-			}
-		}
-
-		internal void ExecuteStartup(MiNetServer server)
-		{
-			foreach (object plugin in _plugins)
-			{
-				IStartup startupClass = plugin as IStartup;
-				if (startupClass == null) continue;
-
-				try
-				{
-					startupClass.Configure(server);
-				}
-				catch (Exception ex)
-				{
-					Log.Warn("Execute Startup class failed", ex);
-				}
-			}
-		}
-
-		internal void EnablePlugins(MiNetServer server, LevelManager levelManager)
-		{
-			foreach (object plugin in _plugins.ToArray())
-			{
-				IPlugin enablingPlugin = plugin as IPlugin;
-				if (enablingPlugin == null) continue;
-
-				try
-				{
-					enablingPlugin.OnEnable(new PluginContext(server, this, levelManager));
-				}
-				catch (Exception ex)
-				{
-					Log.Warn("On enable plugin", ex);
-				}
-			}
-		}
-
-		internal void DisablePlugins()
-		{
-			foreach (object plugin in _plugins)
-			{
-				IPlugin enablingPlugin = plugin as IPlugin;
-				if (enablingPlugin == null) continue;
-
-				try
-				{
-					enablingPlugin.OnDisable();
-				}
-				catch (Exception ex)
-				{
-					Log.Warn("On disable plugin", ex);
-				}
-			}
-		}
-
-		public void HandleCommand(UserManager<User> userManager, string message, Player player)
-		{
-			try
-			{
-				string commandText = message.Split(' ')[0];
-				message = message.Replace(commandText, "").Trim();
-				commandText = commandText.Replace("/", "").Replace(".", "");
-
-				string[] arguments = message.Split(new[] {' '}, StringSplitOptions.RemoveEmptyEntries);
-
-				List<CommandAttribute> foundCommands = new List<CommandAttribute>();
-				foreach (var handlerEntry in _pluginCommands)
-				{
-					CommandAttribute commandAttribute = handlerEntry.Value;
-					if (!commandText.Equals(commandAttribute.Command, StringComparison.InvariantCultureIgnoreCase)) continue;
-
-					MethodInfo method = handlerEntry.Key;
-					if (method == null) return;
-
-					foundCommands.Add(commandAttribute);
-
-					var authorizationAttributes = method.GetCustomAttributes<AuthorizeAttribute>(true);
-					foreach (AuthorizeAttribute authorizationAttribute in authorizationAttributes)
-					{
-						if (userManager == null)
-						{
-							player.SendMessage($"UserManager not found. You are not permitted to use this command!");
-							return;
-						}
-
-						User user = userManager.FindByName(player.Username);
-						if (user == null)
-						{
-							player.SendMessage($"No registered user '{player.Username}' found. You are not permitted to use this command!");
-							return;
-						}
-
-						var userIdentity = userManager.CreateIdentity(user, "none");
-						if (!authorizationAttribute.OnAuthorization(new GenericPrincipal(userIdentity, new string[0])))
-						{
-							player.SendMessage("You are not permitted to use this command!");
-							return;
-						}
-					}
-
-					if (ExecuteCommand(method, player, arguments)) return;
-				}
-
-				foreach (var commandAttribute in foundCommands)
-				{
-					player.SendMessage($"Usage: {commandAttribute.Usage}");
-				}
-			}
-			catch (Exception ex)
-			{
-				Log.Warn(ex);
-			}
-		}
-
-		private static bool IsParams(ParameterInfo param)
-		{
-			return Attribute.IsDefined(param, typeof (ParamArrayAttribute));
-		}
-
-		private bool ExecuteCommand(MethodInfo method, Player player, string[] args)
-		{
-			Log.Info($"Execute command {method}");
-
-			var parameters = method.GetParameters();
-
-			int addLenght = 0;
-			if (parameters.Length > 0 && parameters[0].ParameterType == typeof (Player))
-			{
-				addLenght = 1;
-			}
-
-			if (IsParams(parameters.Last()))
-			{
-				// method params ex: int int params int[] 
-				// input ex:           1  1  1 1 1 
-				// so arguments in must be at least the lenght of method arguments
-				if (parameters.Length - 1 > args.Length + addLenght) return false;
-			}
-			else
-			{
-				if (parameters.Length != args.Length + addLenght) return false;
-			}
-
-			object[] objectArgs = new object[parameters.Length];
-
-			for (int k = 0; k < parameters.Length; k++)
-			{
-				var parameter = parameters[k];
-				int i = k - addLenght;
-				if (k == 0 && addLenght == 1)
-				{
-					if (parameter.ParameterType == typeof (Player))
-					{
-						objectArgs[k] = player;
-						continue;
-					}
-					Log.WarnFormat("Command method {0} missing Player as first argument.", method.Name);
-					return false;
-				}
-
-				if (parameter.ParameterType == typeof (string))
-				{
-					objectArgs[k] = args[i];
-					continue;
-				}
-				if (parameter.ParameterType == typeof (byte))
-				{
-					byte value;
-					if (!byte.TryParse(args[i], out value)) return false;
-					objectArgs[k] = value;
-					continue;
-				}
-				if (parameter.ParameterType == typeof (short))
-				{
-					short value;
-					if (!short.TryParse(args[i], out value)) return false;
-					objectArgs[k] = value;
-					continue;
-				}
-				if (parameter.ParameterType == typeof (int))
-				{
-					int value;
-					if (!int.TryParse(args[i], out value)) return false;
-					objectArgs[k] = value;
-					continue;
-				}
-				if (parameter.ParameterType == typeof (bool))
-				{
-					bool value;
-					if (!bool.TryParse(args[i], out value)) return false;
-					objectArgs[k] = value;
-					continue;
-				}
-				if (parameter.ParameterType == typeof (float))
-				{
-					float value;
-					if (!float.TryParse(args[i], out value)) return false;
-					objectArgs[k] = value;
-					continue;
-				}
-				if (parameter.ParameterType == typeof (double))
-				{
-					double value;
-					if (!double.TryParse(args[i], out value)) return false;
-					objectArgs[k] = value;
-					continue;
-				}
-
-				if (IsParams(parameter) && parameter.ParameterType == typeof (string[]))
-				{
-					List<string> strings = new List<string>();
-					for (int j = i; j < args.Length; j++)
-					{
-						strings.Add(args[j]);
-					}
-					objectArgs[k] = strings.ToArray();
-					continue;
-				}
-
-				return false;
-			}
-
-			object pluginInstance = _plugins.FirstOrDefault(plugin => plugin.GetType() == method.DeclaringType);
-			if (pluginInstance == null) return false;
-
-			if (method.IsStatic)
-			{
-				method.Invoke(null, objectArgs);
-			}
-			else
-			{
-				if (method.DeclaringType == null) return false;
-
-				method.Invoke(pluginInstance, objectArgs);
-			}
-
-			return true;
-		}
-
-		internal Package PluginPacketHandler(Package message, bool isReceiveHandler, Player player)
-		{
-            if(message == null) return null;
-
-            Package currentPackage = message;
-			Package returnPacket = currentPackage;
-
-			try
-			{
-				Dictionary<MethodInfo, PacketHandlerAttribute> packetHandlers;
-				if (isReceiveHandler)
-				{
-					packetHandlers = _packetHandlerDictionary;
-				}
-				else
-				{
-					packetHandlers = _packetSendHandlerDictionary;
-				}
-
-				if (packetHandlers == null) return message;
-
-				foreach (var handler in packetHandlers)
-				{
-					if (handler.Value == null) continue;
-					if (handler.Key == null) continue;
-
-					PacketHandlerAttribute atrib = handler.Value;
-					if (atrib.PacketType == null) continue;
-
-                    if (!atrib.PacketType.IsInstanceOfType(currentPackage) && atrib.PacketType != currentPackage.GetType())
+                    Type[] types = newAssembly.GetExportedTypes();
+                    foreach (Type type in types)
                     {
-                        //Log.Warn($"No assignable {atrib.PacketType.Name} from {currentPackage.GetType().Name}");
+                        try
+                        {
+                            // If no PluginAttribute and does not implement IPlugin interface, not a valid plugin
+                            if (!type.IsDefined(typeof(PluginAttribute), true) && !typeof(IPlugin).IsAssignableFrom(type)) continue;
+                            if (type.IsDefined(typeof(PluginAttribute), true))
+                            {
+                                PluginAttribute pluginAttribute = Attribute.GetCustomAttribute(type, typeof(PluginAttribute), true) as PluginAttribute;
+                                if (pluginAttribute != null)
+                                {
+                                    if (!Config.GetProperty(pluginAttribute.PluginName + ".Enabled", true)) continue;
+                                }
+                            }
+                            var ctor = type.GetConstructor(Type.EmptyTypes);
+                            if (ctor != null)
+                            {
+                                var plugin = ctor.Invoke(null);
+                                _plugins.Add(plugin);
+                                LoadCommands(type);
+                                CreatePacketHandlers(plugin);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.WarnFormat("Failed loading plugin type {0} as a plugin.", type);
+                            Log.Debug("Plugin loader caught exception, but is moving on.", ex);
+                        }
+                    }
+                }
+            }
+        }
+
+        private Assembly MyResolveEventHandler(object sender, ResolveEventArgs args)
+        {
+            if (_currentPath == null) return null;
+
+            try
+            {
+                AssemblyName name = new AssemblyName(args.Name);
+                string assemblyPath = _currentPath + "\\" + name.Name + ".dll";
+                return Assembly.LoadFile(assemblyPath);
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    AssemblyName name = new AssemblyName(args.Name);
+                    string assemblyPath = _currentPath + "\\" + name.Name + ".exe";
+                    return Assembly.LoadFile(assemblyPath);
+                }
+                catch (Exception)
+                {
+                    return Assembly.LoadFile(args.Name + ".dll");
+                }
+            }
+        }
+
+        public void LoadCommands(object instance)
+        {
+            if (!_plugins.Contains(instance)) _plugins.Add(instance);
+            LoadCommands(instance.GetType());
+        }
+
+        private void LoadCommands(Type type)
+        {
+            var methods = type.GetMethods();
+            foreach (MethodInfo method in methods)
+            {
+                CommandAttribute commandAttribute = Attribute.GetCustomAttribute(method, typeof(CommandAttribute), false) as CommandAttribute;
+                if (commandAttribute == null) continue;
+
+                if (string.IsNullOrEmpty(commandAttribute.Command))
+                {
+                    commandAttribute.Command = method.Name;
+                }
+
+                StringBuilder sb = new StringBuilder();
+                sb.Append("/");
+                sb.Append(commandAttribute.Command);
+                var parameters = method.GetParameters();
+                if (parameters.Length > 0) sb.Append(" ");
+                bool isFirstParam = true;
+                foreach (var parameter in parameters)
+                {
+                    if (isFirstParam && parameter.ParameterType == typeof(Player))
+                    {
+                        continue;
+                    }
+                    isFirstParam = false;
+
+                    sb.AppendFormat("<{0}> ", parameter.Name);
+                }
+                commandAttribute.Usage = sb.ToString().Trim();
+
+                DescriptionAttribute descriptionAttribute = Attribute.GetCustomAttribute(method, typeof(DescriptionAttribute), false) as DescriptionAttribute;
+                if (descriptionAttribute != null) commandAttribute.Description = descriptionAttribute.Description;
+
+                _pluginCommands.Add(method, commandAttribute);
+                Log.Debug($"Loaded command {commandAttribute.Usage}");
+            }
+        }
+
+        public void UnloadCommands(object instance)
+        {
+            if (!_plugins.Contains(instance)) return;
+            _plugins.Remove(instance);
+
+            var methods = _pluginCommands.Keys.Where(info => info.DeclaringType == instance.GetType()).ToArray();
+            foreach (var method in methods)
+            {
+                _pluginCommands.Remove(method);
+            }
+        }
+
+        public void LoadPacketHandlers(object instance)
+        {
+            if (!_plugins.Contains(instance)) _plugins.Add(instance);
+            CreatePacketHandlers(instance);
+        }
+
+        private void CreatePacketHandlers(object instance)
+        {
+            Type type = instance.GetType();
+            foreach (MethodInfo method in type.GetMethods())
+            {
+                PacketHandlerAttribute packetHandlerAttribute = Attribute.GetCustomAttribute(method, typeof(PacketHandlerAttribute), false) as PacketHandlerAttribute;
+                if (packetHandlerAttribute != null)
+                {
+                    ParameterInfo[] parameters = method.GetParameters();
+                    if (parameters.Length < 1 || parameters.Length > 2)
+                    {
                         continue;
                     }
 
-                    //Log.Warn($"IS assignable {atrib.PacketType.Name} from {currentPackage.GetType().Name}");
+                    if (!typeof(Package).IsAssignableFrom(parameters[0].ParameterType) || (parameters.Length == 2 && typeof(Player) != parameters[1].ParameterType))
+                    {
+                        continue;
+                    }
 
-                    MethodInfo method = handler.Key;
-					if (method == null) continue;
-					if (method.IsStatic)
-					{
-						//TODO: Move below and set pluginInstance = null instead
-						method.Invoke(null, new object[] {currentPackage, player});
-					}
-					else
-					{
-						object pluginInstance = _plugins.FirstOrDefault(plugin => plugin.GetType() == method.DeclaringType);
-						if (pluginInstance == null) continue;
+                    // TODO: Figure out potential alternative for tracking registration of static methods.
+                    if (method.IsStatic && parameters.Length != 2)
+                    {
+                        continue;
+                    }
 
-						if (method.ReturnType == typeof (void))
-						{
-							ParameterInfo[] parameters = method.GetParameters();
-							if (parameters.Length == 1)
-							{
-								method.Invoke(pluginInstance, new object[] {currentPackage});
-							}
-							else if (parameters.Length == 2 && parameters[1].ParameterType == typeof (Player))
-							{
-								method.Invoke(pluginInstance, new object[] {currentPackage, player});
-							}
-						}
-						else
-						{
-							ParameterInfo[] parameters = method.GetParameters();
-							if (parameters.Length == 1)
-							{
-								returnPacket = method.Invoke(pluginInstance, new object[] {currentPackage}) as Package;
-							}
-							else if (parameters.Length == 2 && parameters[1].ParameterType == typeof (Player))
-							{
-								returnPacket = method.Invoke(pluginInstance, new object[] {currentPackage, player}) as Package;
-							}
-						}
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				//For now we will just ignore this, not to big of a deal.
-				//Will have to think a bit more about this later on.
-				Log.Warn("Plugin Error: ", ex);
-				Log.Warn("Plugin Error: ", ex.InnerException);
-			}
+                    if (packetHandlerAttribute.PacketType == null)
+                    {
+                        packetHandlerAttribute.PacketType = parameters[0].ParameterType;
+                    }
+                    else
+                    {
+                        if (packetHandlerAttribute.PacketType != parameters[0].ParameterType)
+                        {
+                            // TODO: Is it more appropriate to throw an error, or log a warning here?
+                            continue;
+                        }
+                    }
 
-			return returnPacket;
-		}
-	}
+                    IDictionary<Type, ISet<IPackageEventHandler>> target = _packageReceiveHandlers;
+                    if (method.GetCustomAttribute<SendAttribute>(false) != null)
+                    {
+                        target = _packageSendHandlers;
+                    }
+
+                    Type package = packetHandlerAttribute.PacketType;
+                    ISet<IPackageEventHandler> handlers;
+                    if (!target.TryGetValue(package, out handlers))
+                    {
+                        handlers = new HashSet<IPackageEventHandler>();
+                        target.Add(package, handlers);
+                    }
+
+                    try
+                    {
+                        IPackageEventHandler handler = _packageEventHandlerGenerator.Generate(instance, method, package);
+                        if (!handlers.Add(handler))
+                        {
+                            Log.WarnFormat("Failed to register handler for {0}#{1}, already registered?", type.FullName, method.Name);
+                        }
+
+                        if (!_registrantHandlerMapping.TryGetValue(instance, out handlers))
+                        {
+                            handlers = new HashSet<IPackageEventHandler>();
+                            _registrantHandlerMapping.Add(instance, handlers);
+                        }
+                        handlers.Add(handler);
+                    }
+                    catch (Exception exception)
+                    {
+                        Log.ErrorFormat("Failed to generate handler for {0}#{1} using {2}: {3}", type.FullName, method.Name, _packageEventHandlerGenerator.GetType().FullName, exception);
+                    }
+                }
+            }
+        }
+
+        public void UnloadPacketHandlers(object instance)
+        {
+            ISet<IPackageEventHandler> handlers;
+            if (_registrantHandlerMapping.TryGetValue(instance, out handlers))
+            {
+                _registrantHandlerMapping.Remove(instance);
+
+                foreach (IPackageEventHandler handler in handlers)
+                {
+                    foreach (var set in _packageSendHandlers.Values)
+                    {
+                        set.Remove(handler);
+                    }
+
+                    foreach (var set in _packageReceiveHandlers.Values)
+                    {
+                        set.Remove(handler);
+                    }
+                }
+            }
+        }
+
+        internal void ExecuteStartup(MiNetServer server)
+        {
+            foreach (object plugin in _plugins)
+            {
+                IStartup startupClass = plugin as IStartup;
+                if (startupClass == null) continue;
+
+                try
+                {
+                    startupClass.Configure(server);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn("Execute Startup class failed", ex);
+                }
+            }
+        }
+
+        internal void EnablePlugins(MiNetServer server, LevelManager levelManager)
+        {
+            foreach (object plugin in _plugins.ToArray())
+            {
+                IPlugin enablingPlugin = plugin as IPlugin;
+                if (enablingPlugin == null) continue;
+
+                try
+                {
+                    enablingPlugin.OnEnable(new PluginContext(server, this, levelManager));
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn("On enable plugin", ex);
+                }
+            }
+        }
+
+        internal void DisablePlugins()
+        {
+            foreach (object plugin in _plugins)
+            {
+                IPlugin enablingPlugin = plugin as IPlugin;
+                if (enablingPlugin == null) continue;
+
+                try
+                {
+                    enablingPlugin.OnDisable();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn("On disable plugin", ex);
+                }
+                finally
+                {
+                    UnloadPacketHandlers(enablingPlugin);
+                }
+            }
+        }
+
+        public void HandleCommand(UserManager<User> userManager, string message, Player player)
+        {
+            try
+            {
+                string commandText = message.Split(' ')[0];
+                message = message.Replace(commandText, "").Trim();
+                commandText = commandText.Replace("/", "").Replace(".", "");
+
+                string[] arguments = message.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                List<CommandAttribute> foundCommands = new List<CommandAttribute>();
+                foreach (var handlerEntry in _pluginCommands)
+                {
+                    CommandAttribute commandAttribute = handlerEntry.Value;
+                    if (!commandText.Equals(commandAttribute.Command, StringComparison.InvariantCultureIgnoreCase)) continue;
+
+                    MethodInfo method = handlerEntry.Key;
+                    if (method == null) return;
+
+                    foundCommands.Add(commandAttribute);
+
+                    var authorizationAttributes = method.GetCustomAttributes<AuthorizeAttribute>(true);
+                    foreach (AuthorizeAttribute authorizationAttribute in authorizationAttributes)
+                    {
+                        if (userManager == null)
+                        {
+                            player.SendMessage($"UserManager not found. You are not permitted to use this command!");
+                            return;
+                        }
+
+                        User user = userManager.FindByName(player.Username);
+                        if (user == null)
+                        {
+                            player.SendMessage($"No registered user '{player.Username}' found. You are not permitted to use this command!");
+                            return;
+                        }
+
+                        var userIdentity = userManager.CreateIdentity(user, "none");
+                        if (!authorizationAttribute.OnAuthorization(new GenericPrincipal(userIdentity, new string[0])))
+                        {
+                            player.SendMessage("You are not permitted to use this command!");
+                            return;
+                        }
+                    }
+
+                    if (ExecuteCommand(method, player, arguments)) return;
+                }
+
+                foreach (var commandAttribute in foundCommands)
+                {
+                    player.SendMessage($"Usage: {commandAttribute.Usage}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warn(ex);
+            }
+        }
+
+        private static bool IsParams(ParameterInfo param)
+        {
+            return Attribute.IsDefined(param, typeof(ParamArrayAttribute));
+        }
+
+        private bool ExecuteCommand(MethodInfo method, Player player, string[] args)
+        {
+            Log.Info($"Execute command {method}");
+
+            var parameters = method.GetParameters();
+
+            int addLenght = 0;
+            if (parameters.Length > 0 && parameters[0].ParameterType == typeof(Player))
+            {
+                addLenght = 1;
+            }
+
+            if (IsParams(parameters.Last()))
+            {
+                // method params ex: int int params int[] 
+                // input ex:           1  1  1 1 1 
+                // so arguments in must be at least the lenght of method arguments
+                if (parameters.Length - 1 > args.Length + addLenght) return false;
+            }
+            else
+            {
+                if (parameters.Length != args.Length + addLenght) return false;
+            }
+
+            object[] objectArgs = new object[parameters.Length];
+
+            for (int k = 0; k < parameters.Length; k++)
+            {
+                var parameter = parameters[k];
+                int i = k - addLenght;
+                if (k == 0 && addLenght == 1)
+                {
+                    if (parameter.ParameterType == typeof(Player))
+                    {
+                        objectArgs[k] = player;
+                        continue;
+                    }
+                    Log.WarnFormat("Command method {0} missing Player as first argument.", method.Name);
+                    return false;
+                }
+
+                if (parameter.ParameterType == typeof(string))
+                {
+                    objectArgs[k] = args[i];
+                    continue;
+                }
+                if (parameter.ParameterType == typeof(byte))
+                {
+                    byte value;
+                    if (!byte.TryParse(args[i], out value)) return false;
+                    objectArgs[k] = value;
+                    continue;
+                }
+                if (parameter.ParameterType == typeof(short))
+                {
+                    short value;
+                    if (!short.TryParse(args[i], out value)) return false;
+                    objectArgs[k] = value;
+                    continue;
+                }
+                if (parameter.ParameterType == typeof(int))
+                {
+                    int value;
+                    if (!int.TryParse(args[i], out value)) return false;
+                    objectArgs[k] = value;
+                    continue;
+                }
+                if (parameter.ParameterType == typeof(bool))
+                {
+                    bool value;
+                    if (!bool.TryParse(args[i], out value)) return false;
+                    objectArgs[k] = value;
+                    continue;
+                }
+                if (parameter.ParameterType == typeof(float))
+                {
+                    float value;
+                    if (!float.TryParse(args[i], out value)) return false;
+                    objectArgs[k] = value;
+                    continue;
+                }
+                if (parameter.ParameterType == typeof(double))
+                {
+                    double value;
+                    if (!double.TryParse(args[i], out value)) return false;
+                    objectArgs[k] = value;
+                    continue;
+                }
+
+                if (IsParams(parameter) && parameter.ParameterType == typeof(string[]))
+                {
+                    List<string> strings = new List<string>();
+                    for (int j = i; j < args.Length; j++)
+                    {
+                        strings.Add(args[j]);
+                    }
+                    objectArgs[k] = strings.ToArray();
+                    continue;
+                }
+
+                return false;
+            }
+
+            object pluginInstance = _plugins.FirstOrDefault(plugin => plugin.GetType() == method.DeclaringType);
+            if (pluginInstance == null) return false;
+
+            if (method.IsStatic)
+            {
+                method.Invoke(null, objectArgs);
+            }
+            else
+            {
+                if (method.DeclaringType == null) return false;
+
+                method.Invoke(pluginInstance, objectArgs);
+            }
+
+            return true;
+        }
+
+        internal Package PluginPacketHandler(Package message, bool isReceiveHandler, Player player)
+        {
+            if (message == null) return null;
+
+            Package result = message;
+            try
+            {
+                IDictionary<Type, ISet<IPackageEventHandler>> packetHandlers = _packageReceiveHandlers;
+                if (!isReceiveHandler)
+                {
+                    packetHandlers = _packageSendHandlers;
+                }
+
+                ISet<IPackageEventHandler> handlers;
+                if (!packetHandlers.TryGetValue(message.GetType(), out handlers))
+                {
+                    return message;
+                }
+
+                foreach (var handler in handlers)
+                {
+                    result = handler.Handle(message, player);
+                }
+            }
+            catch (Exception ex)
+            {
+                //For now we will just ignore this, not to big of a deal.
+                //Will have to think a bit more about this later on.
+                Log.Warn("Plugin Error: ", ex);
+                Log.Warn("Plugin Error: ", ex.InnerException);
+            }
+            return result;
+        }
+    }
 }


### PR DESCRIPTION
Instead of directly relying on `MethodInfo` for all handler invocations we now use `IPackageEventHandler`, excuse the poor choice in naming, it was early and I hadn't had my coffee at the time. Implementations of this interface are provided for by an `IPackageEventHandlerGenerator` allowing for fine grained control of how "events" are fired.

I have implemented two generators, one designed for high performance and another designed simply to conform to the design proposed.

- `ReflectionPackageHandlerGenerator`
  - Utilises classes found in the `System.Reflection` namespace to invoke methods.
- `EmittedPackageHandlerGenerator`
  - Utilises classes found in the `System.Reflection.Emit` namespace to directly invoke handler methods where possible.
  - Returns NOP implementations of `IPackageEventHandler` where methods cannot be invoked
    - As far as I'm aware this only happens when a class is not accessible from the generated `Assembly`.

See `src/MiNET/MiNET.Test/BenchmarkEventHandlerGenerators.cs` for simple benchmarks.

`EmittedPackageHandlerGenerator` requires the ability to generate MSIL on-the-fly and thus may not work on restricted or non-standard systems. 

As with all micro-optimisations, this should be taken with a grain of salt.

I hope you don't mind that I reformatted a few files (Visual Studio defaults) given that they were all over the place.