### PR TITLE
Optimize buffer usage

### DIFF
--- a/src/MiNET/MiNET.Client/MiNetClient.cs
+++ b/src/MiNET/MiNET.Client/MiNetClient.cs
@@ -882,8 +882,8 @@ McpeSetTime:
 				payload = data
 			};
             
-		    var encodedLoginPacket = loginPacket.Encode();
-		    McpeBatch batch = Player.CreateBatchPacket(encodedLoginPacket, 0, encodedLoginPacket.Length, CompressionLevel.Fastest, true);
+			var encodedLoginPacket = loginPacket.Encode();
+			McpeBatch batch = Player.CreateBatchPacket(encodedLoginPacket, 0, encodedLoginPacket.Length, CompressionLevel.Fastest, true);
 
 			Session.CryptoContext = new CryptoContext()
 			{
@@ -966,8 +966,8 @@ McpeSetTime:
 				McpeClientMagic magic = new McpeClientMagic();
 				//SendPackage(magic);
 
-			    var encodedMagic = magic.Encode();
-                var batch = Player.CreateBatchPacket(encodedMagic, 0, encodedMagic.Length, CompressionLevel.Fastest, true);
+				var encodedMagic = magic.Encode();
+				var batch = Player.CreateBatchPacket(encodedMagic, 0, encodedMagic.Length, CompressionLevel.Fastest, true);
 				SendPackage(batch);
 			}
 		}

--- a/src/MiNET/MiNET.Client/MiNetClient.cs
+++ b/src/MiNET/MiNET.Client/MiNetClient.cs
@@ -1577,7 +1577,7 @@ StartGame:
 			var messages = new List<Package>();
 
 			// Get bytes
-			byte[] payload = batch.payload;
+			byte[] payload = batch.payload.Array;
 			// Decompress bytes
 
 			MemoryStream stream = new MemoryStream(payload);

--- a/src/MiNET/MiNET.Client/MiNetClient.cs
+++ b/src/MiNET/MiNET.Client/MiNetClient.cs
@@ -881,14 +881,9 @@ McpeSetTime:
 				payloadLenght = data.Length,
 				payload = data
 			};
-
-			var payload = Player.CompressBytes(loginPacket.Encode(), CompressionLevel.Fastest, true);
-
-			McpeBatch batch = new McpeBatch
-			{
-				payloadSize = payload.Length,
-				payload = payload
-			};
+            
+		    var encodedLoginPacket = loginPacket.Encode();
+		    McpeBatch batch = Player.CreateBatchPacket(encodedLoginPacket, 0, encodedLoginPacket.Length, CompressionLevel.Fastest, true);
 
 			Session.CryptoContext = new CryptoContext()
 			{
@@ -971,13 +966,8 @@ McpeSetTime:
 				McpeClientMagic magic = new McpeClientMagic();
 				//SendPackage(magic);
 
-				var payload = Player.CompressBytes(magic.Encode(), CompressionLevel.Fastest, true);
-
-				McpeBatch batch = new McpeBatch
-				{
-					payloadSize = payload.Length,
-					payload = payload
-				};
+			    var encodedMagic = magic.Encode();
+                var batch = Player.CreateBatchPacket(encodedMagic, 0, encodedMagic.Length, CompressionLevel.Fastest, true);
 				SendPackage(batch);
 			}
 		}

--- a/src/MiNET/MiNET.Service/server.conf
+++ b/src/MiNET/MiNET.Service/server.conf
@@ -15,8 +15,8 @@
 #EnableSecurity=true
 
 motd=§6§l» §6gurun§7HackingServer§6§l «
-#WorldProvider=anvil
-WorldProvider=flat
+WorldProvider=anvil
+#WorldProvider=flat
 #ViewDistance=11
 #MaxViewDistance=8
 #MoveRenderDistance=1
@@ -46,14 +46,14 @@ WorldProvider=flat
 #PCWorldFolder=D:\Downloads\Phain\Phain
 
 # GOOD HUBS
-#PCWorldFolder=D:\Development\Worlds\TopixMedia Lobby
+PCWorldFolder=D:\Development\Worlds\TopixMedia Lobby
 #PCWorldFolder=D:\Development\Worlds\4 Portal Hub by snyed
 #PCWorldFolder=D:\Development\Worlds\HubSpawn [By_ DoomGary]
 
 #PCWorldFolder=D:\Development\Repos\MapsPE\sg.station
 
 #PluginDirectory=../../../TestPlugin/bin/Release;
-#PluginDirectory=../../../TestPlugin/bin/Debug;
+PluginDirectory=../../../TestPlugin/bin/Debug;
 
 #PluginDisabled=true
 #NiceLobby.Enabled=false

--- a/src/MiNET/MiNET.Service/server.conf
+++ b/src/MiNET/MiNET.Service/server.conf
@@ -15,8 +15,8 @@
 #EnableSecurity=true
 
 motd=§6§l» §6gurun§7HackingServer§6§l «
-WorldProvider=anvil
-#WorldProvider=flat
+#WorldProvider=anvil
+WorldProvider=flat
 #ViewDistance=11
 #MaxViewDistance=8
 #MoveRenderDistance=1
@@ -46,14 +46,14 @@ WorldProvider=anvil
 #PCWorldFolder=D:\Downloads\Phain\Phain
 
 # GOOD HUBS
-PCWorldFolder=D:\Development\Worlds\TopixMedia Lobby
+#PCWorldFolder=D:\Development\Worlds\TopixMedia Lobby
 #PCWorldFolder=D:\Development\Worlds\4 Portal Hub by snyed
 #PCWorldFolder=D:\Development\Worlds\HubSpawn [By_ DoomGary]
 
 #PCWorldFolder=D:\Development\Repos\MapsPE\sg.station
 
 #PluginDirectory=../../../TestPlugin/bin/Release;
-PluginDirectory=../../../TestPlugin/bin/Debug;
+#PluginDirectory=../../../TestPlugin/bin/Debug;
 
 #PluginDisabled=true
 #NiceLobby.Enabled=false

--- a/src/MiNET/MiNET.Test/MinetCrytopTest.cs
+++ b/src/MiNET/MiNET.Test/MinetCrytopTest.cs
@@ -430,7 +430,7 @@ PU9A3CHMdEcdw/MEAjBBO1lId8KOCh9UZunsSMfqXiVurpzmhWd6VYZ/32G+M+Mh
 			var messages = new List<Package>();
 
 			// Get bytes
-			byte[] payload = batch.payload;
+			byte[] payload = batch.payload.Array;
 			// Decompress bytes
 
 			Console.WriteLine("Package:\n" + Package.HexDump(payload));

--- a/src/MiNET/MiNET/MiNET.csproj
+++ b/src/MiNET/MiNET/MiNET.csproj
@@ -538,6 +538,7 @@
     <Compile Include="Utils\MetadataIntCoordinates.cs" />
     <Compile Include="Utils\MetadataLong.cs" />
     <Compile Include="Utils\OpenSimplex.cs" />
+    <Compile Include="Utils\PrefixedArray.cs" />
     <Compile Include="Utils\Ray.cs" />
     <Compile Include="Utils\WannabeRandom.cs" />
     <Compile Include="Utils\TextUtils.cs" />

--- a/src/MiNET/MiNET/Net/MCPE Protocol.cs
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.cs
@@ -1370,7 +1370,7 @@ namespace MiNET.Net
 			BeforeEncode();
 
 			Write(payloadSize);
-			Write(payload);
+			Write(payload, payloadSize);
 
 			AfterEncode();
 		}

--- a/src/MiNET/MiNET/Net/MCPE Protocol.cs
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.cs
@@ -1356,8 +1356,7 @@ namespace MiNET.Net
 
 	public partial class McpeBatch : Package<McpeBatch>
 	{
-		public int payloadSize; // = null;
-		public byte[] payload; // = null;
+		public PrefixedArray payload; // = null;
 		public McpeBatch()
 		{
 			Id = 0x06;
@@ -1369,8 +1368,7 @@ namespace MiNET.Net
 
 			BeforeEncode();
 
-			Write(payloadSize);
-			Write(payload, payloadSize);
+			Write(payload);
 
 			AfterEncode();
 		}
@@ -1384,8 +1382,7 @@ namespace MiNET.Net
 
 			BeforeDecode();
 
-			payloadSize = ReadInt();
-			payload = ReadBytes(0);
+			payload = ReadPrefixedArray();
 
 			AfterDecode();
 		}

--- a/src/MiNET/MiNET/Net/MCPE Protocol.tt
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.tt
@@ -143,8 +143,8 @@ foreach (XmlNode pdu in doc.SelectNodes("//pdu"))
 
 		WriteLine(string.Format("\t\t\tWrite({0});", CodeName(field.Attributes["name"].Value)));
 
+			
 	} // foreach
-
 #>
 
 			AfterEncode();

--- a/src/MiNET/MiNET/Net/MCPE Protocol.tt
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.tt
@@ -141,17 +141,10 @@ foreach (XmlNode pdu in doc.SelectNodes("//pdu"))
 	{
 		if(field.NodeType != XmlNodeType.Element) continue;
 
-		if (CodeName(field.Attributes["name"].Value) == "payload" && CodeTypeName(pdu.Attributes["name"].Value) == "McpeBatch")
-		{
-			WriteLine(string.Format("\t\t\tWrite({0}, payloadSize);", CodeName(field.Attributes["name"].Value)));
-		}
-		else
-		{
-			WriteLine(string.Format("\t\t\tWrite({0});", CodeName(field.Attributes["name"].Value)));
-		}
+		WriteLine(string.Format("\t\t\tWrite({0});", CodeName(field.Attributes["name"].Value)));
 
-			
 	} // foreach
+
 #>
 
 			AfterEncode();

--- a/src/MiNET/MiNET/Net/MCPE Protocol.tt
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.tt
@@ -141,7 +141,14 @@ foreach (XmlNode pdu in doc.SelectNodes("//pdu"))
 	{
 		if(field.NodeType != XmlNodeType.Element) continue;
 
-		WriteLine(string.Format("\t\t\tWrite({0});", CodeName(field.Attributes["name"].Value)));
+		if (CodeName(field.Attributes["name"].Value) == "payload" && CodeTypeName(pdu.Attributes["name"].Value) == "McpeBatch")
+		{
+				WriteLine(string.Format("\t\t\tWrite({0}, payloadSize);", CodeName(field.Attributes["name"].Value)));
+		}
+		else
+		{
+				WriteLine(string.Format("\t\t\tWrite({0});", CodeName(field.Attributes["name"].Value)));
+		}
 
 			
 	} // foreach

--- a/src/MiNET/MiNET/Net/MCPE Protocol.tt
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.tt
@@ -143,11 +143,11 @@ foreach (XmlNode pdu in doc.SelectNodes("//pdu"))
 
 		if (CodeName(field.Attributes["name"].Value) == "payload" && CodeTypeName(pdu.Attributes["name"].Value) == "McpeBatch")
 		{
-				WriteLine(string.Format("\t\t\tWrite({0}, payloadSize);", CodeName(field.Attributes["name"].Value)));
+			WriteLine(string.Format("\t\t\tWrite({0}, payloadSize);", CodeName(field.Attributes["name"].Value)));
 		}
 		else
 		{
-				WriteLine(string.Format("\t\t\tWrite({0});", CodeName(field.Attributes["name"].Value)));
+			WriteLine(string.Format("\t\t\tWrite({0});", CodeName(field.Attributes["name"].Value)));
 		}
 
 			

--- a/src/MiNET/MiNET/Net/MCPE Protocol.xml
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.xml
@@ -147,8 +147,7 @@
 	</pdu>
 
 	<pdu id="0x06" online="false" client="false" server="true" name="MCPE_BATCH">
-		<field name="Payload size" type="int" />
-		<field name="Payload" type="byte[]" size="0" />
+    <field name="Payload" type="PrefixedArray" />
 	</pdu>
 
 	<!-- 

--- a/src/MiNET/MiNET/Net/Package.cs
+++ b/src/MiNET/MiNET/Net/Package.cs
@@ -95,15 +95,23 @@ namespace MiNET.Net
 			_writer.Write(value);
 		}
 
-		public void Write(byte[] value, int length)
+		public void Write(PrefixedArray value)
 		{
 			if (value == null)
 			{
-				Log.Warn("Trying to write null byte[]");
+				Log.Warn("Trying to write null PrefixedArray");
 				return;
 			}
 			
-			_writer.Write(value, 0, length);
+			Write(value.Length);
+			_writer.Write(value.Array, 0, value.Length);
+		}
+
+		public PrefixedArray ReadPrefixedArray()
+		{
+			var len = ReadInt();
+			var bytes = ReadBytes(len);
+			return new PrefixedArray(bytes, len);
 		}
 
 		public byte[] ReadBytes(int count)

--- a/src/MiNET/MiNET/Net/Package.cs
+++ b/src/MiNET/MiNET/Net/Package.cs
@@ -95,7 +95,18 @@ namespace MiNET.Net
 			_writer.Write(value);
 		}
 
-		public byte[] ReadBytes(int count)
+        public void Write(byte[] value, int length)
+        {
+            if (value == null)
+            {
+                Log.Warn("Trying to write null byte[]");
+                return;
+            }
+
+            _writer.Write(value, 0, length);
+        }
+
+        public byte[] ReadBytes(int count)
 		{
 			if (count == 0)
 			{

--- a/src/MiNET/MiNET/Net/Package.cs
+++ b/src/MiNET/MiNET/Net/Package.cs
@@ -106,7 +106,7 @@ namespace MiNET.Net
 			_writer.Write(value, 0, length);
 		}
 
-        public byte[] ReadBytes(int count)
+		public byte[] ReadBytes(int count)
 		{
 			if (count == 0)
 			{

--- a/src/MiNET/MiNET/Net/Package.cs
+++ b/src/MiNET/MiNET/Net/Package.cs
@@ -95,15 +95,15 @@ namespace MiNET.Net
 			_writer.Write(value);
 		}
 
-        public void Write(byte[] value, int length)
-        {
-            if (value == null)
-            {
-                Log.Warn("Trying to write null byte[]");
-                return;
-            }
-
-            _writer.Write(value, 0, length);
+		public void Write(byte[] value, int length)
+		{
+			if (value == null)
+			{
+				Log.Warn("Trying to write null byte[]");
+				return;
+			}
+			
+			_writer.Write(value, 0, length);
         }
 
         public byte[] ReadBytes(int count)

--- a/src/MiNET/MiNET/Net/Package.cs
+++ b/src/MiNET/MiNET/Net/Package.cs
@@ -104,7 +104,7 @@ namespace MiNET.Net
 			}
 			
 			_writer.Write(value, 0, length);
-        }
+		}
 
         public byte[] ReadBytes(int count)
 		{

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -1793,53 +1793,55 @@ namespace MiNET
 			}
 		}
 
-	    private static MemoryStream CompressIntoStream(byte[] input, int offset, int length, CompressionLevel compressionLevel, bool writeLen = false)
-	    {
-            MemoryStream stream = MiNetServer.MemoryStreamManager.GetStream();
-            stream.WriteByte(0x78);
-            switch (compressionLevel)
-            {
-                case CompressionLevel.Optimal:
-                    stream.WriteByte(0xda);
-                    break;
-                case CompressionLevel.Fastest:
-                    stream.WriteByte(0x9c);
-                    break;
-                case CompressionLevel.NoCompression:
-                    stream.WriteByte(0x01);
-                    break;
-            }
-            int checksum;
-            using (var compressStream = new ZLibStream(stream, compressionLevel, true))
-            {
-                byte[] lenBytes = BitConverter.GetBytes(length);
-                Array.Reverse(lenBytes);
-                if (writeLen) compressStream.Write(lenBytes, 0, lenBytes.Length); // ??
-                compressStream.Write(input, offset, length);
-                checksum = compressStream.Checksum;
-            }
+		private static MemoryStream CompressIntoStream(byte[] input, int offset, int length, CompressionLevel compressionLevel,
+			bool writeLen = false)
+		{
+			var stream = MiNetServer.MemoryStreamManager.GetStream();
+			stream.WriteByte(0x78);
+			switch (compressionLevel)
+			{
+				case CompressionLevel.Optimal:
+					stream.WriteByte(0xda);
+					break;
+				case CompressionLevel.Fastest:
+					stream.WriteByte(0x9c);
+					break;
+				case CompressionLevel.NoCompression:
+					stream.WriteByte(0x01);
+					break;
+			}
+			int checksum;
+			using (var compressStream = new ZLibStream(stream, compressionLevel, true))
+			{
+				var lenBytes = BitConverter.GetBytes(length);
+				Array.Reverse(lenBytes);
+				if (writeLen) compressStream.Write(lenBytes, 0, lenBytes.Length); // ??
+				compressStream.Write(input, offset, length);
+				checksum = compressStream.Checksum;
+			}
 
-            byte[] checksumBytes = BitConverter.GetBytes(checksum);
-            if (BitConverter.IsLittleEndian)
-            {
-                // Adler32 checksum is big-endian
-                Array.Reverse(checksumBytes);
-            }
-            stream.Write(checksumBytes, 0, checksumBytes.Length);
-	        return stream;
-	    }
-        
-        public static McpeBatch CreateBatchPacket(byte[] input, int offset, int length, CompressionLevel compressionLevel, bool writeLen = false)
-        {
-            using (MemoryStream stream = CompressIntoStream(input, offset, length, compressionLevel, writeLen))
-            {
-                McpeBatch batch = McpeBatch.CreateObject();
-                batch.payload = stream.GetBuffer();
-                batch.payloadSize = (int) stream.Length;
-                batch.Encode();
-                return batch;
-            }
-        }
+			var checksumBytes = BitConverter.GetBytes(checksum);
+			if (BitConverter.IsLittleEndian)
+			{
+				// Adler32 checksum is big-endian
+				Array.Reverse(checksumBytes);
+			}
+			stream.Write(checksumBytes, 0, checksumBytes.Length);
+			return stream;
+		}
+
+		public static McpeBatch CreateBatchPacket(byte[] input, int offset, int length, CompressionLevel compressionLevel,
+			bool writeLen = false)
+		{
+			using (var stream = CompressIntoStream(input, offset, length, compressionLevel, writeLen))
+			{
+				var batch = McpeBatch.CreateObject();
+				batch.payload = stream.GetBuffer();
+				batch.payloadSize = (int) stream.Length;
+				batch.Encode();
+				return batch;
+			}
+		}
 
         public virtual void SendUpdateAttributes()
 		{

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -1843,7 +1843,7 @@ namespace MiNET
 			}
 		}
 
-        public virtual void SendUpdateAttributes()
+		public virtual void SendUpdateAttributes()
 		{
 			//Attribute[generic.absorption, Name: generic.absorption, MinValue: 0, MaxValue: 3, 402823E+38, Value: 0]
 			//Attribute[player.saturation, Name: player.saturation, MinValue: 0, MaxValue: 20, Value: 5]

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -1836,8 +1836,7 @@ namespace MiNET
 			using (var stream = CompressIntoStream(input, offset, length, compressionLevel, writeLen))
 			{
 				var batch = McpeBatch.CreateObject();
-				batch.payload = stream.GetBuffer();
-				batch.payloadSize = (int) stream.Length;
+				batch.payload = new PrefixedArray(stream.GetBuffer(), (int)stream.Length);
 				batch.Encode();
 				return batch;
 			}

--- a/src/MiNET/MiNET/PlayerNetworkSession.cs
+++ b/src/MiNET/MiNET/PlayerNetworkSession.cs
@@ -732,10 +732,10 @@ namespace MiNET
 		{
 			if (messageCount == 0) return;
 
-            //byte[] bufferNoComp = CompressBytes(array, CompressionLevel.NoCompression);
-            //byte[] bufferOptimal = CompressBytes(array, CompressionLevel.Optimal);
-            McpeBatch batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Fastest);
-
+			//byte[] bufferNoComp = CompressBytes(array, CompressionLevel.NoCompression);
+			//byte[] bufferOptimal = CompressBytes(array, CompressionLevel.Optimal);
+			var batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Fastest);
+			
 			memStream.Position = 0;
 			memStream.SetLength(0);
 

--- a/src/MiNET/MiNET/PlayerNetworkSession.cs
+++ b/src/MiNET/MiNET/PlayerNetworkSession.cs
@@ -732,19 +732,9 @@ namespace MiNET
 		{
 			if (messageCount == 0) return;
 
-			McpeBatch batch = McpeBatch.CreateObject();
-			var array = memStream.ToArray();
-			//byte[] bufferNoComp = CompressBytes(array, CompressionLevel.NoCompression);
-			//byte[] bufferOptimal = CompressBytes(array, CompressionLevel.Optimal);
-			byte[] bufferSpeed = Player.CompressBytes(array, CompressionLevel.Fastest);
-
-			//Log.Error($"No comp: {bufferNoComp.Length}, Optimal: {bufferOptimal.Length}, Fastest: {bufferSpeed.Length}");
-
-			var buffer = bufferSpeed;
-
-			batch.payloadSize = buffer.Length;
-			batch.payload = buffer;
-			batch.Encode();
+            //byte[] bufferNoComp = CompressBytes(array, CompressionLevel.NoCompression);
+            //byte[] bufferOptimal = CompressBytes(array, CompressionLevel.Optimal);
+            McpeBatch batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Fastest);
 
 			memStream.Position = 0;
 			memStream.SetLength(0);

--- a/src/MiNET/MiNET/PlayerNetworkSession.cs
+++ b/src/MiNET/MiNET/PlayerNetworkSession.cs
@@ -311,7 +311,7 @@ namespace MiNET
 				var messages = new List<Package>();
 
 				// Get bytes
-				byte[] payload = batch.payload;
+				byte[] payload = batch.payload.Array;
 				// Decompress bytes
 
 				MemoryStream stream = new MemoryStream(payload);

--- a/src/MiNET/MiNET/ServerInfo.cs
+++ b/src/MiNET/MiNET/ServerInfo.cs
@@ -46,8 +46,8 @@ namespace MiNET
 					int threads;
 					int portThreads;
 					ThreadPool.GetAvailableThreads(out threads, out portThreads);
-					double kbitPerSecondOut = Interlocked.Exchange(ref TotalPacketSizeOut, 0) * 8 / 1000000D;
-					double kbitPerSecondIn = Interlocked.Exchange(ref TotalPacketSizeIn, 0) * 8 / 1000000D;
+					double kbitPerSecondOut = Interlocked.Exchange(ref TotalPacketSizeOut, 0) * 8/1000000D;
+					double kbitPerSecondIn = Interlocked.Exchange(ref TotalPacketSizeIn, 0) * 8/1000000D;
 					Log.WarnFormat("TT {4:00}ms Ly {6:00}ms {5} Pl(s) Pkt(#/s) (Out={0} In={2}) ACK/NAK/RESD/FTO(#/s) {1}/{11}/{12}/{13} Tput(Mbit/s) ({3:F} {7:F}) Avail {8}kb Threads {9} Compl.ports {10}",
 						Interlocked.Exchange(ref NumberOfPacketsOutPerSecond, 0),
 						Interlocked.Exchange(ref NumberOfAckReceive, 0),

--- a/src/MiNET/MiNET/ServerInfo.cs
+++ b/src/MiNET/MiNET/ServerInfo.cs
@@ -7,7 +7,7 @@ namespace MiNET
 {
 	public class ServerInfo
 	{
-		private static readonly ILog Log = LogManager.GetLogger(typeof (ServerInfo));
+		private static readonly ILog Log = LogManager.GetLogger(typeof(ServerInfo));
 
 		private LevelManager _levelManager;
 		public ConcurrentDictionary<IPEndPoint, PlayerNetworkSession> PlayerSessions { get; private set; }
@@ -39,30 +39,30 @@ namespace MiNET
 			_levelManager = levelManager;
 			PlayerSessions = playerSessions;
 			{
-				ThroughPut = new Timer(delegate(object state)
+				ThroughPut = new Timer(delegate (object state)
 				{
 					NumberOfPlayers = PlayerSessions.Count;
 
 					int threads;
 					int portThreads;
 					ThreadPool.GetAvailableThreads(out threads, out portThreads);
-					double kbitPerSecondOut = Interlocked.Exchange(ref TotalPacketSizeOut, 0) * 8/1000000D;
-					double kbitPerSecondIn = Interlocked.Exchange(ref TotalPacketSizeIn, 0) * 8/1000000D;
-					/*Log.WarnFormat("TT {4:00}ms Ly {6:00}ms {5} Pl(s) Pkt(#/s) (Out={0} In={2}) ACK/NAK/RESD/FTO(#/s) {1}/{11}/{12}/{13} Tput(Mbit/s) ({3:F} {7:F}) Avail {8}kb Threads {9} Compl.ports {10}",
+					double kbitPerSecondOut = Interlocked.Exchange(ref TotalPacketSizeOut, 0) * 8 / 1000000D;
+					double kbitPerSecondIn = Interlocked.Exchange(ref TotalPacketSizeIn, 0) * 8 / 1000000D;
+					Log.WarnFormat("TT {4:00}ms Ly {6:00}ms {5} Pl(s) Pkt(#/s) (Out={0} In={2}) ACK/NAK/RESD/FTO(#/s) {1}/{11}/{12}/{13} Tput(Mbit/s) ({3:F} {7:F}) Avail {8}kb Threads {9} Compl.ports {10}",
 						Interlocked.Exchange(ref NumberOfPacketsOutPerSecond, 0),
 						Interlocked.Exchange(ref NumberOfAckReceive, 0),
 						Interlocked.Exchange(ref NumberOfPacketsInPerSecond, 0),
 						kbitPerSecondOut,
-						0,
+						0 /*_level.LastTickProcessingTime*/,
 						NumberOfPlayers,
 						Latency,
-						kbitPerSecondIn, 
+						kbitPerSecondIn,
 						AvailableBytes / 1000,
 						threads,
 						portThreads,
 						Interlocked.Exchange(ref NumberOfNakReceive, 0),
 						Interlocked.Exchange(ref NumberOfResends, 0),
-						Interlocked.Exchange(ref NumberOfFails, 0));*/
+						Interlocked.Exchange(ref NumberOfFails, 0));
 
 					//Interlocked.Exchange(ref NumberOfAckReceive, 0);
 					//Interlocked.Exchange(ref NumberOfNakReceive, 0);

--- a/src/MiNET/MiNET/ServerInfo.cs
+++ b/src/MiNET/MiNET/ServerInfo.cs
@@ -48,12 +48,12 @@ namespace MiNET
 					ThreadPool.GetAvailableThreads(out threads, out portThreads);
 					double kbitPerSecondOut = Interlocked.Exchange(ref TotalPacketSizeOut, 0) * 8/1000000D;
 					double kbitPerSecondIn = Interlocked.Exchange(ref TotalPacketSizeIn, 0) * 8/1000000D;
-					Log.WarnFormat("TT {4:00}ms Ly {6:00}ms {5} Pl(s) Pkt(#/s) (Out={0} In={2}) ACK/NAK/RESD/FTO(#/s) {1}/{11}/{12}/{13} Tput(Mbit/s) ({3:F} {7:F}) Avail {8}kb Threads {9} Compl.ports {10}",
+					/*Log.WarnFormat("TT {4:00}ms Ly {6:00}ms {5} Pl(s) Pkt(#/s) (Out={0} In={2}) ACK/NAK/RESD/FTO(#/s) {1}/{11}/{12}/{13} Tput(Mbit/s) ({3:F} {7:F}) Avail {8}kb Threads {9} Compl.ports {10}",
 						Interlocked.Exchange(ref NumberOfPacketsOutPerSecond, 0),
 						Interlocked.Exchange(ref NumberOfAckReceive, 0),
 						Interlocked.Exchange(ref NumberOfPacketsInPerSecond, 0),
 						kbitPerSecondOut,
-						0 /*_level.LastTickProcessingTime*/,
+						0,
 						NumberOfPlayers,
 						Latency,
 						kbitPerSecondIn, 
@@ -62,7 +62,7 @@ namespace MiNET
 						portThreads,
 						Interlocked.Exchange(ref NumberOfNakReceive, 0),
 						Interlocked.Exchange(ref NumberOfResends, 0),
-						Interlocked.Exchange(ref NumberOfFails, 0));
+						Interlocked.Exchange(ref NumberOfFails, 0));*/
 
 					//Interlocked.Exchange(ref NumberOfAckReceive, 0);
 					//Interlocked.Exchange(ref NumberOfNakReceive, 0);

--- a/src/MiNET/MiNET/Utils/NbtBinaryReader.cs
+++ b/src/MiNET/MiNET/Utils/NbtBinaryReader.cs
@@ -200,9 +200,9 @@ namespace MiNET.Utils
 		}
 
 	    protected override void Dispose(bool disposing)
-	    {
-	        base.Dispose(disposing);
-            _buffer.Dispose();
-	    }
+		{
+			base.Dispose(disposing);
+			_buffer.Dispose();
+		}
 	}
 }

--- a/src/MiNET/MiNET/Utils/NbtBinaryReader.cs
+++ b/src/MiNET/MiNET/Utils/NbtBinaryReader.cs
@@ -170,7 +170,7 @@ namespace MiNET.Utils
 		{
 			get
 			{
-				UpdateChecksum(_buffer.ToArray(), 0, _buffer.Length);
+				UpdateChecksum(_buffer.GetBuffer(), 0, _buffer.Length);
 				return ((adler32B*65536) + adler32A);
 			}
 		}
@@ -198,5 +198,11 @@ namespace MiNET.Utils
 			_buffer.Write(array, offset, count);
 			base.Write(array, offset, count);
 		}
+
+	    protected override void Dispose(bool disposing)
+	    {
+	        base.Dispose(disposing);
+            _buffer.Dispose();
+	    }
 	}
 }

--- a/src/MiNET/MiNET/Utils/NbtBinaryReader.cs
+++ b/src/MiNET/MiNET/Utils/NbtBinaryReader.cs
@@ -199,7 +199,7 @@ namespace MiNET.Utils
 			base.Write(array, offset, count);
 		}
 
-	    protected override void Dispose(bool disposing)
+		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
 			_buffer.Dispose();

--- a/src/MiNET/MiNET/Utils/PrefixedArray.cs
+++ b/src/MiNET/MiNET/Utils/PrefixedArray.cs
@@ -1,0 +1,21 @@
+﻿namespace MiNET.Utils
+{
+	public sealed class PrefixedArray
+	{
+		private readonly byte[] _array;
+		private readonly int _length;
+
+		public PrefixedArray(byte[] array) : this(array, array.Length)
+		{
+		}
+
+		public PrefixedArray(byte[] array, int length)
+		{
+			_array = array;
+			_length = length;
+		}
+
+		public byte[] Array => _array;
+		public int Length => _length;
+	}
+}

--- a/src/MiNET/MiNET/Utils/PrefixedArray.cs
+++ b/src/MiNET/MiNET/Utils/PrefixedArray.cs
@@ -2,20 +2,17 @@
 {
 	public sealed class PrefixedArray
 	{
-		private readonly byte[] _array;
-		private readonly int _length;
-
 		public PrefixedArray(byte[] array) : this(array, array.Length)
 		{
 		}
 
 		public PrefixedArray(byte[] array, int length)
 		{
-			_array = array;
-			_length = length;
+			Array = array;
+			Length = length;
 		}
 
-		public byte[] Array => _array;
-		public int Length => _length;
+		public byte[] Array { get; }
+		public int Length { get; }
 	}
 }

--- a/src/MiNET/MiNET/Worlds/ChunkColumn.cs
+++ b/src/MiNET/MiNET/Worlds/ChunkColumn.cs
@@ -268,16 +268,15 @@ namespace MiNET.Worlds
 				byte[] bytes = fullChunkData.Encode();
 				fullChunkData.PutPool();
 
-				MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream();
-				memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
-				memStream.Write(bytes, 0, bytes.Length);
-
-				McpeBatch batch = McpeBatch.CreateObject();
-				byte[] buffer = Player.CompressBytes(memStream.ToArray(), CompressionLevel.Optimal);
-				batch.payloadSize = buffer.Length;
-				batch.payload = buffer;
-				batch.Encode();
-				batch.MarkPermanent();
+			    McpeBatch batch;
+			    using (MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream())
+			    {
+                    memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
+                    memStream.Write(bytes, 0, bytes.Length);
+                    batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal);
+                    batch.Encode();
+                    batch.MarkPermanent();
+                }
 
 				_cachedBatch = batch;
 				_cache = null;

--- a/src/MiNET/MiNET/Worlds/ChunkColumn.cs
+++ b/src/MiNET/MiNET/Worlds/ChunkColumn.cs
@@ -274,7 +274,6 @@ namespace MiNET.Worlds
 					memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
 					memStream.Write(bytes, 0, bytes.Length);
 					batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal);
-					batch.Encode();
 					batch.MarkPermanent();
 				}
 

--- a/src/MiNET/MiNET/Worlds/ChunkColumn.cs
+++ b/src/MiNET/MiNET/Worlds/ChunkColumn.cs
@@ -268,7 +268,7 @@ namespace MiNET.Worlds
 				byte[] bytes = fullChunkData.Encode();
 				fullChunkData.PutPool();
 
-			    McpeBatch batch;
+				McpeBatch batch;
 				using (MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream())
 				{
 					memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);

--- a/src/MiNET/MiNET/Worlds/ChunkColumn.cs
+++ b/src/MiNET/MiNET/Worlds/ChunkColumn.cs
@@ -269,14 +269,14 @@ namespace MiNET.Worlds
 				fullChunkData.PutPool();
 
 			    McpeBatch batch;
-			    using (MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream())
-			    {
-                    memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
-                    memStream.Write(bytes, 0, bytes.Length);
-                    batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal);
-                    batch.Encode();
-                    batch.MarkPermanent();
-                }
+				using (MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream())
+				{
+					memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
+					memStream.Write(bytes, 0, bytes.Length);
+					batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal);
+					batch.Encode();
+					batch.MarkPermanent();
+				}
 
 				_cachedBatch = batch;
 				_cache = null;

--- a/src/MiNET/MiNET/Worlds/ChunkColumn.cs
+++ b/src/MiNET/MiNET/Worlds/ChunkColumn.cs
@@ -387,7 +387,6 @@ namespace MiNET.Worlds
 
 			//private McpeBatch _cachedBatch = null;
 			McpeBatch batch = McpeBatch.CreateObject();
-			batch.payloadSize = _cachedBatch.payloadSize;
 			batch.payload = _cachedBatch.payload;
 			batch.Encode();
 			batch.MarkPermanent();

--- a/src/MiNET/MiNET/Worlds/Level.cs
+++ b/src/MiNET/MiNET/Worlds/Level.cs
@@ -171,12 +171,12 @@ namespace MiNET.Worlds
 
 		internal static McpeBatch CreateMcpeBatch(byte[] bytes)
 		{
-		    using (MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream())
-		    {
-                memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
-                memStream.Write(bytes, 0, bytes.Length);
-                return Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal);
-            }
+			using (MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream())
+			{
+				memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
+				memStream.Write(bytes, 0, bytes.Length);
+				return Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal);
+			}
 		}
 
 		private object _playerWriteLock = new object();

--- a/src/MiNET/TestPlugin/NiceLobby/NiceLobbyPlugin.cs
+++ b/src/MiNET/TestPlugin/NiceLobby/NiceLobbyPlugin.cs
@@ -816,13 +816,9 @@ namespace TestPlugin.NiceLobby
 			MemoryStream memStream = MiNetServer.MemoryStreamManager.GetStream();
 			memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
 			memStream.Write(bytes, 0, bytes.Length);
-
-			McpeBatch batch = McpeBatch.CreateObject();
-			byte[] buffer = Player.CompressBytes(memStream.ToArray(), CompressionLevel.Optimal);
+            
+			var batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal));
 			batch.MarkPermanent();
-			batch.payloadSize = buffer.Length;
-			batch.payload = buffer;
-			batch.Encode();
 			return batch;
 		}
 

--- a/src/MiNET/TestPlugin/NiceLobby/NiceLobbyPlugin.cs
+++ b/src/MiNET/TestPlugin/NiceLobby/NiceLobbyPlugin.cs
@@ -817,7 +817,7 @@ namespace TestPlugin.NiceLobby
 			memStream.Write(BitConverter.GetBytes(Endian.SwapInt32(bytes.Length)), 0, 4);
 			memStream.Write(bytes, 0, bytes.Length);
             
-			var batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal));
+			var batch = Player.CreateBatchPacket(memStream.GetBuffer(), 0, (int) memStream.Length, CompressionLevel.Optimal);
 			batch.MarkPermanent();
 			return batch;
 		}


### PR DESCRIPTION
This makes the usage of `RecyclableMemoryStream`s more friendly. This is still not complete (a lot of progress has to be made if serious improvement is to be made).

This implementation prefers `GetBuffer()` over `ToArray()` and introduces a new `Player` method that will compress byte arrays into `McpeBatch` packets directly. Some places where proper disposal was not used correctly have also been fixed. Support for writing a specific part of a byte array in `Package` has also been added to permit further optimization.

It's important to note that while this patch makes progress on improving the amount of memory stress in MiNET, many improvements can be had,