### PR TITLE
Fix Block Bounding boxes (For better Arrow shooting)

### DIFF
--- a/src/MiNET/MiNET/Blocks/Block.cs
+++ b/src/MiNET/MiNET/Blocks/Block.cs
@@ -149,7 +149,7 @@ namespace MiNET.Blocks
 		{
 		}
 
-		public BoundingBox GetBoundingBox()
+		public virtual BoundingBox GetBoundingBox()
 		{
 			return new BoundingBox(Coordinates, Coordinates + 1);
 		}

--- a/src/MiNET/MiNET/Blocks/StoneSlab.cs
+++ b/src/MiNET/MiNET/Blocks/StoneSlab.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+using MiNET.Utils;
+
 namespace MiNET.Blocks
 {
 	public class StoneSlab : Block
@@ -7,6 +10,11 @@ namespace MiNET.Blocks
 			BlastResistance = 30;
 			Hardness = 2;
 			IsTransparent = true; // Partial
-		}
-	}
+        }
+
+        public override BoundingBox GetBoundingBox()
+        {
+            return new BoundingBox(Coordinates, (Vector3)Coordinates + new Vector3(1f, 0.5f, 1f));
+        }
+    }
 }

--- a/src/MiNET/MiNET/Blocks/WoodSlab.cs
+++ b/src/MiNET/MiNET/Blocks/WoodSlab.cs
@@ -1,3 +1,6 @@
+using System.Numerics;
+using MiNET.Utils;
+
 namespace MiNET.Blocks
 {
 	public class WoodSlab : Block
@@ -8,5 +11,10 @@ namespace MiNET.Blocks
 			Hardness = 2;
 			IsFlammable = true;
 		}
+
+	    public override BoundingBox GetBoundingBox()
+	    {
+            return new BoundingBox(Coordinates, (Vector3) Coordinates + new Vector3(1f, 0.5f, 1f));
+	    }
 	}
 }

--- a/src/MiNET/MiNET/Entities/Projectiles/Projectile.cs
+++ b/src/MiNET/MiNET/Entities/Projectiles/Projectile.cs
@@ -195,7 +195,7 @@ namespace MiNET.Entities.Projectiles
 
 					BlockCoordinates coord = new BlockCoordinates(nextPos);
 					Block block = Level.GetBlock(coord);
-					collided = block.Id != 0 && (block.GetBoundingBox()).Contains(nextPos.ToVector3());
+					collided = block.IsSolid && (block.GetBoundingBox()).Contains(nextPos.ToVector3());
 					if (collided)
 					{
 						SetIntersectLocation(block.GetBoundingBox(), KnownPosition);


### PR DESCRIPTION
This only does the bounding boxes for Slabs, and leaves the rest down to Block.IsSolid. But this will make it so you can actually shoot arrows through the middle of slabs fine.

(See screenshot - note that i disabled arrow despawning for the screenshot, but NOT in the pull)
![ss 2016-09-06 at 02 06 28](https://cloud.githubusercontent.com/assets/983207/18258949/95ed0e46-73d6-11e6-8d88-1569fbe8d5a3.jpg)
