### PR TITLE
ReadIPEndPoint returning invalid port

### DIFF
--- a/src/MiNET/MiNET/Net/Package.cs
+++ b/src/MiNET/MiNET/Net/Package.cs
@@ -518,7 +518,7 @@ namespace MiNET.Net
 			string ipAddress = $"{ReadByte()}.{ReadByte()}.{ReadByte()}.{ReadByte()}";
 			int port = ReadShort(true);
 
-			return new IPEndPoint(IPAddress.Parse(ipAddress), 19132);
+			return new IPEndPoint(IPAddress.Parse(ipAddress), port);
 		}
 
 		public void Write(IPEndPoint[] endpoints)


### PR DESCRIPTION
ReadIPEndPoint is currently returning a static port of 19132 rather than returning the read port.