### PR TITLE
Fixed bug double-pass join

### DIFF
--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -683,9 +683,9 @@ namespace MiNET
 			SetPosition(SpawnPosition);
 
 			LastUpdatedTime = DateTime.UtcNow;
+			if(!_haveJoined)
+				OnPlayerJoin(new PlayerEventArgs(this));
 			_haveJoined = true;
-
-			OnPlayerJoin(new PlayerEventArgs(this));
 		}
 
 		public virtual void HandleMcpeRespawn()


### PR DESCRIPTION
This fixes a bug : when a player is teleported a lot of times on levels, sometimes OnPlayerJoin may be repeated a second time.