### PR TITLE
Change the SendMessage to a single player.

### DIFF
--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -2356,7 +2356,11 @@ namespace MiNET
 
 		public virtual void SendMessage(string text, MessageType type = MessageType.Chat, Player sender = null)
 		{
-			Level.BroadcastMessage(text, type, sender, new[] {this});
+			McpeText message = McpeText.CreateObject();
+			message.type = (byte) type;
+			message.source = sender == null ? "" : sender.Username;
+			message.message = text;
+			SendPackage(message);
 		}
 
 		public virtual void BroadcastEntityEvent()


### PR DESCRIPTION
The fact that SendMessage is implemented before was using BroadCastMessage working through RelayBroadcast that sends via parallels foreach.In my tests sending a single player using BroadCastMessage is 300-400 ticks of the processor,while normal SendPackage 50-100 ticks of the processor.