### PR TITLE
Remove offsets for SpawnLevel

### DIFF
--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -851,13 +851,11 @@ namespace MiNET
 				}
 			}
 
-			// send teleport straight up, no chunk loading
-			// +1000000 on X/Z axis is to unload the previously loaded chunks (https://bugs.mojang.com/browse/MCPE-19818)
 			SetPosition(new PlayerLocation
 			{
-				X = KnownPosition.X + 1000000,
+				X = KnownPosition.X,
 				Y = 4000,
-				Z = KnownPosition.Z + 1000000,
+				Z = KnownPosition.Z,
 				Yaw = 91,
 				Pitch = 28,
 				HeadYaw = 91,


### PR DESCRIPTION
Bug was fixed by Mojang with chunks not correctly being cleared