### PR TITLE
Fix Bad packet 132

### DIFF
--- a/src/MiNET/MiNET/LoginMessageHandler.cs
+++ b/src/MiNET/MiNET/LoginMessageHandler.cs
@@ -393,6 +393,13 @@ namespace MiNET
 				_session.Disconnect($"Wrong version ({_playerInfo.ProtocolVersion}) of Minecraft. Upgrade to join this server.");
 				return;
 			}
+			
+			if (_playerInfo.ProtocolVersion > 113)
+			{
+				Log.Warn($"Wrong version ({_playerInfo.ProtocolVersion}) of Minecraft. Upgrade to join this server.");
+				_session.Disconnect($"Wrong version ({_playerInfo.ProtocolVersion}) of Minecraft. Downgrade to join this server.");
+				return;
+			}
 
 			if (Config.GetProperty("ForceXBLAuthentication", false) && _playerInfo.CertificateData.ExtraData.Xuid == null)
 			{


### PR DESCRIPTION
Fix 
```
2017-08-13 20:14:38,315 [DedicatedThreadPool-93f28dda-64ea-4796-baa5-db30ced8fd96_8] WARN  MiNET.MiNetServer - Bad packet 132
84 01 00 00 60 02 f0 01 00 00 00 00 00 00 13 04  Į..`.?.........
8f 86 6d d4 4a bc 04 80 ff ff fe 4a bc 04 ff ff  φm?J?.????J?.??
ff ff 00 00 04 ff ff ff ff 00 00 04 ff ff ff ff  ??...????...????
00 00 04 ff ff ff ff 00 00 04 ff ff ff ff 00 00  ...????...????..
04 ff ff ff ff 00 00 04 ff ff ff ff 00 00 04 ff  .????...????...?
ff ff ff 00 00 04 ff ff ff ff 00 00 00 00 00 00  ???...????......
4a bc 04 00 00 00 00 00 00 00 36 e7 00 00 48 00  J?........6?..H.
00 00 00 00 00 00 36 e7                          ......6?

System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
   at System.IO.__Error.EndOfFile()
   at System.IO.BinaryReader.FillBuffer(Int32 numBytes)
   at System.IO.BinaryReader.ReadInt64()
   at MiNET.Net.Package.ReadLong() in C:\Users\TIGER\Desktop\MiNet-sc\MiNET\src\MiNET\MiNET\Net\Package.cs:line 324
   at MiNET.Net.NewIncomingConnection.DecodePackage() in C:\Users\TIGER\Desktop\MiNet-sc\MiNET\src\MiNET\MiNET\Net\MCPE Protocol.cs:line 1237
   at MiNET.Net.Package.Decode(Byte[] buffer) in C:\Users\TIGER\Desktop\MiNet-sc\MiNET\src\MiNET\MiNET\Net\Package.cs:line 1599
   at MiNET.Net.PackageFactory.CreatePackage(Byte messageId, Byte[] buffer, String ns) in C:\Users\TIGER\Desktop\MiNet-sc\MiNET\src\MiNET\MiNET\Net\MCPE Protocol.cs:line 121
   at MiNET.Net.ConnectedPackage.DecodePackage() in C:\Users\TIGER\Desktop\MiNet-sc\MiNET\src\MiNET\MiNET\Net\ConnectedPackage.cs:line 206
   at MiNET.Net.Package.Decode(Byte[] buffer) in C:\Users\TIGER\Desktop\MiNet-sc\MiNET\src\MiNET\MiNET\Net\Package.cs:line 1599
   at MiNET.MiNetServer.ProcessMessage(Byte[] receiveBytes, IPEndPoint senderEndpoint) in C:\Users\TIGER\Desktop\MiNet-sc\MiNET\src\MiNET\MiNET\MiNetServer.cs:line 387
```

packet Form MCPE 1.2++