### PR TITLE
Add missing Gold/Iron Nuggets/Ingots

### DIFF
--- a/src/MiNET/MiNET/Items/ItemFactory.cs
+++ b/src/MiNET/MiNET/Items/ItemFactory.cs
@@ -150,6 +150,8 @@ namespace MiNET.Items
 			else if (id == 261) item = new ItemBow();
 			else if (id == 262) item = new ItemArrow();
 			else if (id == 263) item = new ItemCoal();
+			else if (id == 265) item = new ItemIronIngot();
+			else if (id == 266) item = new ItemGoldIngot();
 			else if (id == 267) item = new ItemIronSword();
 			else if (id == 268) item = new ItemWoodenSword();
 			else if (id == 269) item = new ItemWoodenShovel();
@@ -216,6 +218,7 @@ namespace MiNET.Items
 			else if (id == 364) item = new ItemCookedBeef();
 			else if (id == 365) item = new ItemRawChicken();
 			else if (id == 366) item = new ItemCookedChicken();
+			else if (id == 371) item = new ItemGoldNugget();
 			else if (id == 373) item = new ItemPotion(metadata);
 			else if (id == 380) item = new ItemCauldron();
 			else if (id == 383) item = new ItemSpawnEgg(metadata);
@@ -233,6 +236,7 @@ namespace MiNET.Items
 			else if (id == 430) item = new ItemAcaciaDoor();
 			else if (id == 431) item = new ItemDarkOakDoor();
 			else if (id == 444) item = new ItemElytra();
+			else if (id == 452) item = new ItemIronNugget();
 			else if (id == 458) item = new ItemBeetrootSeeds();
 			else if (id <= 255)
 			{

--- a/src/MiNET/MiNET/Items/ItemGoldIngot.cs
+++ b/src/MiNET/MiNET/Items/ItemGoldIngot.cs
@@ -1,0 +1,9 @@
+﻿namespace MiNET.Items
+{
+	public class ItemGoldIngot : Item
+	{
+		public ItemGoldIngot() : base(266)
+		{
+		}
+	}
+}

--- a/src/MiNET/MiNET/Items/ItemGoldNugget.cs
+++ b/src/MiNET/MiNET/Items/ItemGoldNugget.cs
@@ -1,0 +1,9 @@
+﻿namespace MiNET.Items
+{
+	public class ItemGoldNugget : Item
+	{
+		public ItemGoldNugget() : base(371)
+		{
+		}
+	}
+}

--- a/src/MiNET/MiNET/Items/ItemIronIngot.cs
+++ b/src/MiNET/MiNET/Items/ItemIronIngot.cs
@@ -1,0 +1,9 @@
+﻿namespace MiNET.Items
+{
+	public class ItemIronIngot : Item
+	{
+		public ItemIronIngot() : base(265)
+		{
+		}
+	}
+}

--- a/src/MiNET/MiNET/Items/ItemIronNugget.cs
+++ b/src/MiNET/MiNET/Items/ItemIronNugget.cs
@@ -1,0 +1,9 @@
+﻿namespace MiNET.Items
+{
+	public class ItemIronNugget : Item
+	{
+		public ItemIronNugget() : base(452)
+		{
+		}
+	}
+}

--- a/src/MiNET/MiNET/MiNET.csproj
+++ b/src/MiNET/MiNET/MiNET.csproj
@@ -434,6 +434,10 @@
     <Compile Include="Entities\Projectiles\Snowball.cs" />
     <Compile Include="Entities\Projectiles\Projectile.cs" />
     <Compile Include="Entities\Vehicles\Minecart.cs" />
+    <Compile Include="Items\ItemGoldIngot.cs" />
+    <Compile Include="Items\ItemGoldNugget.cs" />
+    <Compile Include="Items\ItemIronIngot.cs" />
+    <Compile Include="Items\ItemIronNugget.cs" />
     <Compile Include="Utils\Skins\Bone.cs" />
     <Compile Include="Utils\Skins\Cube.cs" />
     <Compile Include="Utils\Skins\Geometry.cs" />


### PR DESCRIPTION
Crafting handled client-side(?) or irrelevant, and these items have no additional handling.
Should be useful as a shortcut instead of doing bypasses to get at the Item constructor, if these aren't directly useful.