### PR TITLE
Basic Handling for EntityPickRequest

### DIFF
--- a/src/MiNET/MiNET/LoginMessageHandler.cs
+++ b/src/MiNET/MiNET/LoginMessageHandler.cs
@@ -433,6 +433,11 @@ namespace MiNET
 		{
 		}
 
+		public void HandleMcpeEntityPickRequest(McpeEntityPickRequest message)
+		{
+			
+		}
+
 		public void HandleMcpePlayerAction(McpePlayerAction message)
 		{
 		}

--- a/src/MiNET/MiNET/Net/MCPE Protocol Documentation.md
+++ b/src/MiNET/MiNET/Net/MCPE Protocol Documentation.md
@@ -940,8 +940,8 @@ Wiki: [Block Pick Request](https://github.com/NiclasOlofsson/MiNET/wiki//Protoco
 ### Entity Pick Request (0x23)
 Wiki: [Entity Pick Request](https://github.com/NiclasOlofsson/MiNET/wiki//Protocol-EntityPickRequest)
 
-**Sent from server:** true  
-**Sent from client:** false
+**Sent from server:** false  
+**Sent from client:** true
 
 
 
@@ -950,6 +950,8 @@ Wiki: [Entity Pick Request](https://github.com/NiclasOlofsson/MiNET/wiki//Protoc
 
 | Name | Type | Size |
 |:-----|:-----|:-----|
+|Runtime Entity ID | ulong |  |
+|Selected Slot | byte |  |
 -----------------------------------------------------------------------
 ### Player Action (0x24)
 Wiki: [Player Action](https://github.com/NiclasOlofsson/MiNET/wiki//Protocol-PlayerAction)

--- a/src/MiNET/MiNET/Net/MCPE Protocol.cs
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.cs
@@ -56,6 +56,7 @@ namespace MiNET.Net
 		void HandleMcpeMobArmorEquipment(McpeMobArmorEquipment message);
 		void HandleMcpeInteract(McpeInteract message);
 		void HandleMcpeBlockPickRequest(McpeBlockPickRequest message);
+		void HandleMcpeEntityPickRequest(McpeEntityPickRequest message);
 		void HandleMcpePlayerAction(McpePlayerAction message);
 		void HandleMcpeEntityFall(McpeEntityFall message);
 		void HandleMcpeAnimate(McpeAnimate message);
@@ -3703,6 +3704,8 @@ namespace MiNET.Net
 	public partial class McpeEntityPickRequest : Package<McpeEntityPickRequest>
 	{
 
+		public ulong runtimeEntityId; // = null;
+		public byte selectedSlot; // = null;
 
 		public McpeEntityPickRequest()
 		{
@@ -3716,6 +3719,8 @@ namespace MiNET.Net
 
 			BeforeEncode();
 
+			Write(runtimeEntityId);
+			Write(selectedSlot);
 
 			AfterEncode();
 		}
@@ -3729,6 +3734,8 @@ namespace MiNET.Net
 
 			BeforeDecode();
 
+			runtimeEntityId = ReadUlong();
+			selectedSlot = ReadByte();
 
 			AfterDecode();
 		}
@@ -3740,6 +3747,8 @@ namespace MiNET.Net
 		{
 			base.ResetPackage();
 
+			runtimeEntityId=default(ulong);
+			selectedSlot=default(byte);
 		}
 
 	}

--- a/src/MiNET/MiNET/Net/MCPE Protocol.xml
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.xml
@@ -503,7 +503,9 @@
 		<field name="Selected Slot" type="byte" />
 	</pdu>
 
-	<pdu id="0x23" online="false" client="false" server="true" name="MCPE_ENTITY_PICK_REQUEST">
+	<pdu id="0x23" online="false" client="true" server="false" name="MCPE_ENTITY_PICK_REQUEST">
+		<field name="Runtime Entity ID" type="ulong" />
+		<field name="Selected Slot" type="byte" />
 	</pdu>
 
 	<pdu id="0x24" online="false" client="true" server="false" name="MCPE_PLAYER_ACTION">

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -2411,7 +2411,17 @@ namespace MiNET
 
 		public virtual void HandleMcpeEntityPickRequest(McpeEntityPickRequest message)
 		{
-			
+			if (GameMode != GameMode.Creative)
+			{
+				return;
+			}
+
+			if (Level.Entities.TryGetValue((long)message.runtimeEntityId, out var entity))
+			{
+				Item item = new ItemSpawnEgg((short)entity.EntityTypeId);
+
+				Inventory.SetInventorySlot(Inventory.InHandSlot, item);
+			}
 		}
 
 		protected virtual int CalculateDamage(Entity target)

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -2409,6 +2409,11 @@ namespace MiNET
 		{
 		}
 
+		public virtual void HandleMcpeEntityPickRequest(McpeEntityPickRequest message)
+		{
+			
+		}
+
 		protected virtual int CalculateDamage(Entity target)
 		{
 			int damage = Inventory.GetItemInHand().GetDamage(); //Item Damage.

--- a/src/MiNET/MiNET/PlayerNetworkSession.cs
+++ b/src/MiNET/MiNET/PlayerNetworkSession.cs
@@ -586,6 +586,12 @@ namespace MiNET
 			{
 				handler.HandleMcpeBlockPickRequest((McpeBlockPickRequest) message);
 			}
+
+			else if (typeof(McpeEntityPickRequest) == message.GetType())
+			{
+				handler.HandleMcpeEntityPickRequest((McpeEntityPickRequest)message);
+			}
+
 			else if (typeof (McpeModalFormResponse) == message.GetType())
 			{
 				handler.HandleMcpeModalFormResponse((McpeModalFormResponse) message);


### PR DESCRIPTION
Includes dodgy workaround for the long read.
Not the best solution, but it 'works'.

ulong would be best converted back to the long later, but since this is all auto-generated it's the best solution so far.