### PR TITLE
Fixed dropping items with NBT.

### DIFF
--- a/src/MiNET/MiNET/PlayerInventory.cs
+++ b/src/MiNET/MiNET/PlayerInventory.cs
@@ -146,6 +146,7 @@ namespace MiNET
 			if (existingItem is ItemAir || existingItem.Id == 0 || existingItem.Id == -1)
 			{
 				Slots[si] = ItemFactory.GetItem(item.Id, item.Metadata, item.Count);
+				Slots[si].ExtraData = item.ExtraData;
 				item.Count = 0;
 				if (update) SendSetSlot(si);
 				return true;


### PR DESCRIPTION
If you'll try to drop item with NBT(for example, fireworks or enchanted items) and pick up it, NBT will disappear.