### PR TITLE
Fixed inability to unmount entities that don't extend Mob class. 

### DIFF
--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -289,10 +289,10 @@ namespace MiNET
 		{
 			if (IsRiding && Vehicle > 0)
 			{
-				if (Level.TryGetEntity(Vehicle, out Mob mob))
+				if (Level.TryGetEntity(Vehicle, out Entity entity))
 				{
-					mob.IsRearing = true;
-					mob.BroadcastSetEntityData();
+                    entity.IsRearing = true;
+                    entity.BroadcastSetEntityData();
 				}
 			}
 		}
@@ -2388,9 +2388,9 @@ namespace MiNET
 			{
 				case 3:
 				{
-					if (Level.TryGetEntity(Vehicle, out Mob mob))
+					if (Level.TryGetEntity(Vehicle, out Entity entity))
 					{
-						mob.Unmount(this);
+						entity.Unmount(this);
 					}
 
 					break;

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -291,8 +291,8 @@ namespace MiNET
 			{
 				if (Level.TryGetEntity(Vehicle, out Entity entity))
 				{
-                    entity.IsRearing = true;
-                    entity.BroadcastSetEntityData();
+					entity.IsRearing = true;
+					entity.BroadcastSetEntityData();
 				}
 			}
 		}


### PR DESCRIPTION
If you'll create, for example, `class Bike : Entity`, mount it and then try to unmount it will not call `entity.Unmount` method.