### PR TITLE
Fixed bad nbf/exp/iat in JWT for client

### DIFF
--- a/src/MiNET/MiNET/Utils/CryptoUtils.cs
+++ b/src/MiNET/MiNET/Utils/CryptoUtils.cs
@@ -180,12 +180,13 @@ namespace MiNET.Utils
 
 			string b64Key = Convert.ToBase64String(ecKey.PublicKey.ToDerEncoded());
 
-			long exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeMilliseconds();
+			long iat = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+			long exp = DateTimeOffset.UtcNow.AddDays(1).ToUnixTimeSeconds();
 
 			CertificateData certificateData = new CertificateData
 			{
 				Exp = exp,
-				Iat = exp,
+				Iat = iat,
 				ExtraData = new ExtraData
 				{
 					DisplayName = username,
@@ -194,7 +195,7 @@ namespace MiNET.Utils
 				Iss = "self",
 				IdentityPublicKey = b64Key,
 				CertificateAuthority = true,
-				Nbf = exp,
+				Nbf = iat,
 				RandomNonce = new Random().Next(),
 			};
 


### PR DESCRIPTION
these should be msec, and nbf should be before the current time in order to pass verification