### PR TITLE
Removed .NET Framework libs.

### DIFF
--- a/src/MiNET/MiNET/MiNET.csproj
+++ b/src/MiNET/MiNET/MiNET.csproj
@@ -37,14 +37,13 @@
 	<ItemGroup>
 		<PackageReference Include="CoreCompat.System.Drawing.v2" Version="5.2.0-preview1-r131" />
 		<PackageReference Include="jose-jwt" Version="2.4.0" />
-		<PackageReference Include="LibNoise" Version="0.2.0" />
+		<PackageReference Include="LibNoise.NetStandart" Version="0.2.0" />
 		<PackageReference Include="log4net" Version="2.0.8" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
 		<PackageReference Include="MiNET.astar" Version="1.0.14" />
 		<PackageReference Include="MiNET.fnbt" Version="1.0.17" />
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
-		<PackageReference Include="SharpAvi" Version="2.1.1" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
It is really annoying when you compile plugin and it throws millions of warns like that:

![image](https://user-images.githubusercontent.com/15432454/43399704-69775406-9414-11e8-877f-dd8c88a492ef.png)

So this PR fixes that by removing SharpAvi(why is it even there?) and replacing LibNoise to .NET Standart 