### PR TITLE
Configuration abstraction, centralization, grouping

### DIFF
--- a/src/MiNET/MiNET.Client/MiNetClient.cs
+++ b/src/MiNET/MiNET.Client/MiNetClient.cs
@@ -47,6 +47,8 @@ using Jose;
 using log4net;
 using log4net.Config;
 using MiNET.Blocks;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Crafting;
 using MiNET.Entities;
 using MiNET.Items;
@@ -71,6 +73,7 @@ namespace MiNET.Client
 	public class MiNetClient
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof (MiNetClient));
+		private static readonly IConfiguration Config = ConfigurationProvider.Configuration;
 
 		private IPEndPoint _clientEndpoint;
 		private IPEndPoint _serverEndpoint;
@@ -1405,7 +1408,7 @@ namespace MiNET.Client
 
 			McpeLogin loginPacket = new McpeLogin
 			{
-				protocolVersion = Config.GetProperty("EnableEdu", false) ? 111 : McpeProtocolInfo.ProtocolVersion,
+				protocolVersion = Config.Security.EnableEdu ? 111 : McpeProtocolInfo.ProtocolVersion,
 				payload = data
 			};
 
@@ -2542,10 +2545,10 @@ namespace MiNET.Client
 
 			string typeName = message.GetType().Name;
 
-			string includePattern = Config.GetProperty("TracePackets.Include", ".*");
-			string excludePattern = Config.GetProperty("TracePackets.Exclude", null);
-			int verbosity = Config.GetProperty("TracePackets.Verbosity", 0);
-			verbosity = Config.GetProperty($"TracePackets.Verbosity.{typeName}", verbosity);
+			string includePattern = Config.Debug.TracePacketsInclude;
+			string excludePattern = Config.Debug.TracePacketsExclude;
+			int verbosity = Config.Debug.TracePacketsVerbosity;
+			verbosity = Config.Debug.TracePacketsVerbosityFor(typeName);
 
 			if (!Regex.IsMatch(typeName, includePattern))
 			{
@@ -2587,10 +2590,10 @@ namespace MiNET.Client
 
 			string typeName = message.GetType().Name;
 
-			string includePattern = Config.GetProperty("TracePackets.Include", ".*");
-			string excludePattern = Config.GetProperty("TracePackets.Exclude", "");
-			int verbosity = Config.GetProperty("TracePackets.Verbosity", 0);
-			verbosity = Config.GetProperty($"TracePackets.Verbosity.{typeName}", verbosity);
+			string includePattern = Config.Debug.TracePacketsInclude;
+			string excludePattern = Config.Debug.TracePacketsExclude;
+			int verbosity = Config.Debug.TracePacketsVerbosity;
+			verbosity = Config.Debug.TracePacketsVerbosityFor(typeName);
 
 
 			if (!Regex.IsMatch(typeName, includePattern))

--- a/src/MiNET/MiNET.Console/Config/ConfigParser.cs
+++ b/src/MiNET/MiNET.Console/Config/ConfigParser.cs
@@ -31,16 +31,16 @@ using System.Reflection;
 using log4net;
 using MiNET.Worlds;
 
-namespace MiNET.Utils
+namespace MiNET.Console.Config
 {
-	public class Config
+	internal class ConfigParser
 	{
-		private static readonly ILog Log = LogManager.GetLogger(typeof (Config));
+		private static readonly ILog Log = LogManager.GetLogger(typeof (ConfigParser));
 
 		public static string ConfigFileName = "server.conf";
 		private static IReadOnlyDictionary<string, string> KeyValues { get; set; }
 
-		static Config()
+		static ConfigParser()
 		{
 			try
 			{

--- a/src/MiNET/MiNET.Console/Config/Implementation/Configuration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/Configuration.cs
@@ -1,0 +1,52 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config.Contracts;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class Configuration: IConfiguration
+	{
+		public Configuration(IServerConfiguration server, IWorldConfiguration world,
+			ISecurityConfiguration security, IPlayerConfiguration player,
+			IPluginConfiguration plugin, IDebugConfiguration debug,
+			IGameRuleConfiguration gameRules)
+		{
+			Server = server;
+			World = world;
+			Security = security;
+			Player = player;
+			Plugin = plugin;
+			Debug = debug;
+			GameRules = gameRules;
+		}
+
+		public IServerConfiguration Server { get; }
+		public IWorldConfiguration World { get; }
+		public ISecurityConfiguration Security { get; }
+		public IPlayerConfiguration Player { get; }
+		public IPluginConfiguration Plugin { get; }
+		public IDebugConfiguration Debug { get; }
+		public IGameRuleConfiguration GameRules { get; }
+	}
+}

--- a/src/MiNET/MiNET.Console/Config/Implementation/DebugConfiguration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/DebugConfiguration.cs
@@ -1,0 +1,39 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config.Contracts;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class DebugConfiguration: IDebugConfiguration
+	{
+		public bool ProfilerEnabled => ConfigParser.GetProperty("Profiler.Enabled", false);
+		public string TracePacketsInclude => ConfigParser.GetProperty("TracePackets.Include", ".*");
+		public string TracePacketsExclude => ConfigParser.GetProperty("TracePackets.Exclude", null);
+		public int TracePacketsVerbosity => ConfigParser.GetProperty("TracePackets.Verbosity", 0);
+		public int TracePacketsVerbosityFor(string typeName)
+		{
+			return ConfigParser.GetProperty($"TracePackets.Verbosity.{typeName}", TracePacketsVerbosity);
+		}
+	}
+}

--- a/src/MiNET/MiNET.Console/Config/Implementation/GameRuleConfiguration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/GameRuleConfiguration.cs
@@ -1,0 +1,51 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config.Contracts;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class GameRuleConfiguration: IGameRuleConfiguration
+	{
+		public bool DrowningDamage => ConfigParser.GetProperty("GameRule.DrowningDamage", true);
+		public bool CommandBlockOutput => ConfigParser.GetProperty("GameRule.CommandblockOutput", true);
+		public bool DoTiledrops => ConfigParser.GetProperty("GameRule.DoTiledrops", true);
+		public bool DoMobloot => ConfigParser.GetProperty("GameRule.DoMobloot", true);
+		public bool KeepInventory => ConfigParser.GetProperty("GameRule.KeepInventory", true);
+		public bool DoDaylightcycle => ConfigParser.GetProperty("GameRule.DoDaylightcycle", true);
+		public bool DoMobSpawning => ConfigParser.GetProperty("GameRule.DoMobspawning", true);
+		public bool DoEntitydrops => ConfigParser.GetProperty("GameRule.DoEntitydrops", true);
+		public bool DoFiretick => ConfigParser.GetProperty("GameRule.DoFiretick", true);
+		public bool DoWeathercycle => ConfigParser.GetProperty("GameRule.DoWeathercycle", true);
+		public bool Pvp => ConfigParser.GetProperty("GameRule.Pvp", true);
+		public bool Falldamage => ConfigParser.GetProperty("GameRule.Falldamage", true);
+		public bool Firedamage => ConfigParser.GetProperty("GameRule.Firedamage", true);
+		public bool Mobgriefing => ConfigParser.GetProperty("GameRule.Mobgriefing", true);
+		public bool ShowCoordinates => ConfigParser.GetProperty("GameRule.ShowCoordinates", true);
+		public bool NaturalRegeneration => ConfigParser.GetProperty("GameRule.NaturalRegeneration", true);
+		public bool TntExplodes => ConfigParser.GetProperty("GameRule.TntExplodes", true);
+		public bool SendCommandfeedback => ConfigParser.GetProperty("GameRule.SendCommandfeedback", true);
+		public int RandomTickSpeed => ConfigParser.GetProperty("GameRule.RandomTickSpeed", 3);
+		public bool PathFinderPrintPath => ConfigParser.GetProperty("Pathfinder.PrintPath", false);
+	}
+}

--- a/src/MiNET/MiNET.Console/Config/Implementation/PlayerConfiguration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/PlayerConfiguration.cs
@@ -1,0 +1,43 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config;
+using MiNET.Config.Contracts;
+using MiNET.Worlds;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class PlayerConfiguration: IPlayerConfiguration
+	{
+		public PlayerConfiguration(IWorldConfiguration worldConfig)
+		{
+			_worldConfig = worldConfig;
+		}
+
+		private readonly IWorldConfiguration _worldConfig;
+		public GameMode PlayerGameMode => ConfigParser.GetProperty("Player.GameMode", _worldConfig.GameMode);
+		public bool EnableCommands => ConfigParser.GetProperty("EnableCommands", false);
+		public int MaxViewDistance => ConfigParser.GetProperty("MaxViewDistance", 22);
+		public int MoveRenderDistance => ConfigParser.GetProperty("MoveRenderDistance", 1);
+	}
+}

--- a/src/MiNET/MiNET.Console/Config/Implementation/PluginConfiguration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/PluginConfiguration.cs
@@ -1,0 +1,46 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using System;
+using System.IO;
+using System.Reflection;
+using MiNET.Config.Contracts;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class PluginConfiguration: IPluginConfiguration
+	{
+		// Default to the directory we are executing from, and below.
+		private static string DefaultPluginDirectoryPaths =>
+			Path.GetDirectoryName(new Uri(Assembly.GetEntryAssembly().CodeBase).LocalPath);
+
+		public string PluginDirectoryPaths => ConfigParser.GetProperty("PluginDirectory", DefaultPluginDirectoryPaths);
+
+		public bool PluginEnabled(string pluginName)
+		{
+			return ConfigParser.GetProperty(pluginName + ".Enabled", true);
+		}
+
+		public bool PluginDisabled => ConfigParser.GetProperty("PluginDisabled", false);
+	}
+}

--- a/src/MiNET/MiNET.Console/Config/Implementation/SecurityConfiguration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/SecurityConfiguration.cs
@@ -1,0 +1,38 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config.Contracts;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class SecurityConfiguration: ISecurityConfiguration
+	{
+		public bool UseEncryption => ConfigParser.GetProperty("UseEncryption", true);
+		public bool UseEncryptionForAll => ConfigParser.GetProperty("UseEncryptionForAll", false);
+		public bool ForceXBLAuthentication => ConfigParser.GetProperty("ForceXBLAuthentication", false);
+		public string ForceXBLLogin => ConfigParser.GetProperty("ForceXBLLogin", "You must authenticate to XBOX Live to join this server.");
+		public bool EnableEdu => ConfigParser.GetProperty("EnableEdu", false);
+		public string EduUsername => ConfigParser.GetProperty("AAD.username", "");
+		public string EduPassword => ConfigParser.GetProperty("AAD.password", "");
+	}
+}

--- a/src/MiNET/MiNET.Console/Config/Implementation/ServerConfiguration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/ServerConfiguration.cs
@@ -1,0 +1,45 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config.Contracts;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class ServerConfiguration: IServerConfiguration
+	{
+		public ServerRole ServerRole => ConfigParser.GetProperty("ServerRole", ServerRole.Full);
+		public string Ip => ConfigParser.GetProperty("ip", "0.0.0.0");
+		public int Port => ConfigParser.GetProperty("port", 19132);
+		public int InactivityTimeout => ConfigParser.GetProperty("InactivityTimeout", 8500);
+		public int ResendThreshold => ConfigParser.GetProperty("ResendThreshold", 10);
+		public bool ForceOrderingForAll => ConfigParser.GetProperty("ForceOrderingForAll", false);
+		public int MaxNumberOfPlayers => ConfigParser.GetProperty("MaxNumberOfPlayers", 1000);
+		public int MaxNumberOfConcurrentConnects => ConfigParser.GetProperty("MaxNumberOfConcurrentConnects", MaxNumberOfPlayers);
+		public int MinWorkerThreads => ConfigParser.GetProperty("MinWorkerThreads", -1);
+		public int MinCompletionPortThreads => ConfigParser.GetProperty("MinCompletionPortThreads", -1);
+		public bool EnableQuery => ConfigParser.GetProperty("EnableQuery", false);
+		public string Motd => ConfigParser.GetProperty("motd", "MiNET: MCPE Server");
+		public string MotdSecond => ConfigParser.GetProperty("motd-2nd", "MiNET");
+		public string AuthorizeErrorMessage => ConfigParser.GetProperty("Authorize.ErrorMessage", "§cInsufficient permissions. Requires {1}, but player had {0}");
+	}
+}

--- a/src/MiNET/MiNET.Console/Config/Implementation/WorldConfiguration.cs
+++ b/src/MiNET/MiNET.Console/Config/Implementation/WorldConfiguration.cs
@@ -1,0 +1,55 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config.Contracts;
+using MiNET.Worlds;
+
+namespace MiNET.Console.Config.Providers
+{
+	internal class WorldConfiguration: IWorldConfiguration
+	{
+		public GameMode GameMode => ConfigParser.GetProperty("GameMode", GameMode.Survival);
+		public Difficulty Difficulty => ConfigParser.GetProperty("Difficulty", Difficulty.Normal);
+		public string WorldProvider => ConfigParser.GetProperty("WorldProvider", "anvil");
+		public string PCWorldFolder => ConfigParser.GetProperty("PCWorldFolder", "World");
+		public bool SaveEnabled => ConfigParser.GetProperty("Save.Enabled", false);
+		public int SaveInterval => ConfigParser.GetProperty("Save.Interval", 300);
+		public int UnloadInterval => ConfigParser.GetProperty("Unload.Interval", -1);
+		public bool CalculateLights => ConfigParser.GetProperty("CalculateLights", false);
+		public bool CalculateLightsMakeMovie => ConfigParser.GetProperty("CalculateLights.MakeMovie", false);
+		public bool CheckForSafeSpawn => ConfigParser.GetProperty("CheckForSafeSpawn", false);
+		public bool EnableBlockTicking => ConfigParser.GetProperty("EnableBlockTicking", false);
+		public bool EnableChunkTicking => ConfigParser.GetProperty("EnableChunkTicking", false);
+		public int ViewDistance => ConfigParser.GetProperty("ViewDistance", 11);
+		public string Seed => ConfigParser.GetProperty("seed", "noise");
+
+		public string SuperflatOverworldSeed => ConfigParser.GetProperty("superflat.overworld",
+			"3;minecraft:bedrock,2*minecraft:dirt,minecraft:grass;1;village");
+
+		public string SuperflatNetherSeed => ConfigParser.GetProperty("superflat.nether",
+			"3;minecraft:bedrock,2*minecraft:netherrack,3*minecraft:lava,2*minecraft:netherrack,20*minecraft:air,minecraft:bedrock;1;village");
+
+		public string SuperflatTheEndSeed => ConfigParser.GetProperty("superflat.theend",
+			"3;40*minecraft:air,minecraft:bedrock,7*minecraft:endstone;1;village");
+	}
+}

--- a/src/MiNET/MiNET.Console/Startup.cs
+++ b/src/MiNET/MiNET.Console/Startup.cs
@@ -28,6 +28,7 @@ using System.Reflection;
 using System.Threading;
 using log4net;
 using log4net.Config;
+using MiNET.Console.Config.Providers;
 
 namespace MiNET.Console
 {
@@ -40,18 +41,33 @@ namespace MiNET.Console
 			var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
 			XmlConfigurator.Configure(logRepository, new FileInfo("log4net.xml"));
 
+
+			var config = CreateConfig();
 			int threads;
 			int portThreads;
 			ThreadPool.GetMinThreads(out threads, out portThreads);
 			Log.Info($"Threads: {threads}, Port Threads: {portThreads}");
 
-			var service = new MiNetServer();
+			var service = new MiNetServer(config);
 			Log.Info("Starting MiNET");
 			service.StartServer();
 
 			System.Console.WriteLine("MiNET running. Press <enter> to stop service.");
 			System.Console.ReadLine();
 			service.StopServer();
+		}
+
+		private static Configuration CreateConfig()
+		{
+			var serverConfig = new ServerConfiguration();
+			var worldConfig = new WorldConfiguration();
+			var securityConfig = new SecurityConfiguration();
+			var playerConfig = new PlayerConfiguration(worldConfig);
+			var pluginConfig = new PluginConfiguration();
+			var debugConfig = new DebugConfiguration();
+			var gameRuleConfig = new GameRuleConfiguration();
+			return new Configuration(serverConfig, worldConfig, securityConfig, playerConfig, pluginConfig,
+				debugConfig, gameRuleConfig);
 		}
 	}
 }

--- a/src/MiNET/MiNET.Plotter/PlotterLevelManager.cs
+++ b/src/MiNET/MiNET.Plotter/PlotterLevelManager.cs
@@ -25,6 +25,8 @@
 
 using System;
 using System.Linq;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Utils;
 using MiNET.Worlds;
 
@@ -32,48 +34,49 @@ namespace MiNET.Plotter
 {
 	public class PlotterLevelManager : LevelManager
 	{
+		private static readonly IConfiguration Config = ConfigurationProvider.Configuration;
 		public override Level GetLevel(Player player, string name)
 		{
 			Level level = Levels.FirstOrDefault(l => l.LevelId.Equals(name, StringComparison.InvariantCultureIgnoreCase));
 			if (level == null)
 			{
-				int viewDistance = Config.GetProperty("ViewDistance", 11);
+				int viewDistance = Config.World.ViewDistance;
 
-				string basePath = Config.GetProperty("PCWorldFolder", "World").Trim();
+				string basePath = Config.World.PCWorldFolder.Trim();
 
 				var worldProvider = new AnvilWorldProvider(basePath)
 				{
 					MissingChunkProvider = new PlotWorldGenerator(),
-					ReadSkyLight = !Config.GetProperty("CalculateLights", false),
-					ReadBlockLight = !Config.GetProperty("CalculateLights", false),
+					ReadSkyLight = !Config.World.CalculateLights,
+					ReadBlockLight = !Config.World.CalculateLights,
 				};
 
 				level = new Level(this, name, worldProvider, EntityManager, GameMode.Creative, Difficulty.Normal, viewDistance)
 				{
-					EnableBlockTicking = Config.GetProperty("EnableBlockTicking", false),
-					EnableChunkTicking = Config.GetProperty("EnableChunkTicking", false),
-					SaveInterval = Config.GetProperty("Save.Interval", 300),
-					UnloadInterval = Config.GetProperty("Unload.Interval", 30),
+					EnableBlockTicking = Config.World.EnableBlockTicking,
+					EnableChunkTicking = Config.World.EnableChunkTicking,
+					SaveInterval = Config.World.SaveInterval,
+					UnloadInterval = Config.World.UnloadInterval,
 
-					DrowningDamage = Config.GetProperty("GameRule.DrowningDamage", true),
-					CommandblockOutput = Config.GetProperty("GameRule.CommandblockOutput", true),
-					DoTiledrops = Config.GetProperty("GameRule.DoTiledrops", true),
-					DoMobloot = Config.GetProperty("GameRule.DoMobloot", true),
-					KeepInventory = Config.GetProperty("GameRule.KeepInventory", true),
-					DoDaylightcycle = Config.GetProperty("GameRule.DoDaylightcycle", true),
-					DoMobspawning = Config.GetProperty("GameRule.DoMobspawning", true),
-					DoEntitydrops = Config.GetProperty("GameRule.DoEntitydrops", true),
-					DoFiretick = Config.GetProperty("GameRule.DoFiretick", true),
-					DoWeathercycle = Config.GetProperty("GameRule.DoWeathercycle", true),
-					Pvp = Config.GetProperty("GameRule.Pvp", true),
-					Falldamage = Config.GetProperty("GameRule.Falldamage", true),
-					Firedamage = Config.GetProperty("GameRule.Firedamage", true),
-					Mobgriefing = Config.GetProperty("GameRule.Mobgriefing", true),
-					ShowCoordinates = Config.GetProperty("GameRule.ShowCoordinates", true),
-					NaturalRegeneration = Config.GetProperty("GameRule.NaturalRegeneration", true),
-					TntExplodes = Config.GetProperty("GameRule.TntExplodes", true),
-					SendCommandfeedback = Config.GetProperty("GameRule.SendCommandfeedback", true),
-					RandomTickSpeed = Config.GetProperty("GameRule.RandomTickSpeed", 3),
+					DrowningDamage = Config.GameRules.DrowningDamage,
+					CommandblockOutput = Config.GameRules.CommandBlockOutput,
+					DoTiledrops = Config.GameRules.DoTiledrops,
+					DoMobloot = Config.GameRules.DoMobloot,
+					KeepInventory = Config.GameRules.KeepInventory,
+					DoDaylightcycle = Config.GameRules.DoDaylightcycle,
+					DoMobspawning = Config.GameRules.DoMobSpawning,
+					DoEntitydrops = Config.GameRules.DoEntitydrops,
+					DoFiretick = Config.GameRules.DoFiretick,
+					DoWeathercycle = Config.GameRules.DoWeathercycle,
+					Pvp = Config.GameRules.Pvp,
+					Falldamage = Config.GameRules.Falldamage,
+					Firedamage = Config.GameRules.Firedamage,
+					Mobgriefing = Config.GameRules.Mobgriefing,
+					ShowCoordinates = Config.GameRules.ShowCoordinates,
+					NaturalRegeneration = Config.GameRules.NaturalRegeneration,
+					TntExplodes = Config.GameRules.TntExplodes,
+					SendCommandfeedback = Config.GameRules.SendCommandfeedback,
+					RandomTickSpeed = Config.GameRules.RandomTickSpeed,
 				};
 				level.Initialize();
 

--- a/src/MiNET/MiNET.sln.DotSettings
+++ b/src/MiNET/MiNET.sln.DotSettings
@@ -43,6 +43,8 @@ the Original Code is Niclas Olofsson.&#xD;
 &#xD;
 All portions of the code written by Niclas Olofsson are Copyright (c) 2014-$CURRENT_YEAR$ Niclas Olofsson. &#xD;
 All Rights Reserved.</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PC/@EntryIndexedValue">PC</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XBL/@EntryIndexedValue">XBL</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/MiNET/MiNET/Config/ConfigurationProvider.cs
+++ b/src/MiNET/MiNET/Config/ConfigurationProvider.cs
@@ -1,0 +1,32 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Config.Contracts;
+
+namespace MiNET.Config
+{
+	public static class ConfigurationProvider
+	{
+		public static IConfiguration Configuration { get; set; }
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/IConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/IConfiguration.cs
@@ -1,0 +1,36 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+namespace MiNET.Config.Contracts
+{
+	public interface IConfiguration
+	{
+		IServerConfiguration Server { get; }
+		IWorldConfiguration World { get; }
+		ISecurityConfiguration Security { get; }
+		IPlayerConfiguration Player { get; }
+		IPluginConfiguration Plugin { get; }
+		IDebugConfiguration Debug { get; }
+		IGameRuleConfiguration GameRules { get; }
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/IDebugConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/IDebugConfiguration.cs
@@ -1,0 +1,11 @@
+﻿namespace MiNET.Config.Contracts
+{
+	public interface IDebugConfiguration
+	{
+		bool ProfilerEnabled { get; }
+		string TracePacketsInclude { get; }
+		string TracePacketsExclude { get; }
+		int TracePacketsVerbosity { get; }
+		int TracePacketsVerbosityFor(string typeName);
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/IGameRuleConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/IGameRuleConfiguration.cs
@@ -1,0 +1,49 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+namespace MiNET.Config.Contracts
+{
+	public interface IGameRuleConfiguration
+	{
+		bool DrowningDamage { get; }
+		bool CommandBlockOutput { get; }
+		bool DoTiledrops { get; }
+		bool DoMobloot { get; }
+		bool KeepInventory { get; }
+		bool DoDaylightcycle { get; }
+		bool DoMobSpawning { get; }
+		bool DoEntitydrops { get; }
+		bool DoFiretick { get; }
+		bool DoWeathercycle { get; }
+		bool Pvp { get; }
+		bool Falldamage { get; }
+		bool Firedamage { get; }
+		bool Mobgriefing { get; }
+		bool ShowCoordinates { get; }
+		bool NaturalRegeneration { get; }
+		bool TntExplodes { get; }
+		bool SendCommandfeedback { get; }
+		int RandomTickSpeed { get; }
+		bool PathFinderPrintPath { get; }
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/IPlayerConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/IPlayerConfiguration.cs
@@ -1,0 +1,35 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Worlds;
+
+namespace MiNET.Config.Contracts
+{
+	public interface IPlayerConfiguration
+	{
+		GameMode PlayerGameMode { get; }
+		bool EnableCommands { get; }
+		int MaxViewDistance { get; }
+		int MoveRenderDistance { get; }
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/IPluginConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/IPluginConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace MiNET.Config.Contracts
+{
+	public interface IPluginConfiguration
+	{
+		string PluginDirectoryPaths { get; }
+		bool PluginEnabled(string pluginName);
+		bool PluginDisabled { get; }
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/ISecurityConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/ISecurityConfiguration.cs
@@ -1,0 +1,36 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+namespace MiNET.Config.Contracts
+{
+	public interface ISecurityConfiguration
+	{
+		bool UseEncryption { get; }
+		bool UseEncryptionForAll { get; }
+		bool ForceXBLAuthentication { get; }
+		string ForceXBLLogin { get; }
+		bool EnableEdu { get; }
+		string EduUsername { get; }
+		string EduPassword { get; }
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/IServerConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/IServerConfiguration.cs
@@ -1,0 +1,44 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+namespace MiNET.Config.Contracts
+{
+	public interface IServerConfiguration
+	{
+		ServerRole ServerRole { get; }
+		string Ip { get; }
+		int Port { get; }
+		int InactivityTimeout { get; }
+		int ResendThreshold { get; }
+		bool ForceOrderingForAll { get; }
+		int MaxNumberOfPlayers { get; }
+		int MaxNumberOfConcurrentConnects { get; }
+		int MinWorkerThreads { get; }
+		int MinCompletionPortThreads { get; }
+		bool EnableQuery { get; }
+		string Motd { get; }
+		string MotdSecond { get; }
+
+		string AuthorizeErrorMessage { get; }
+	}
+}

--- a/src/MiNET/MiNET/Config/Contracts/IWorldConfiguration.cs
+++ b/src/MiNET/MiNET/Config/Contracts/IWorldConfiguration.cs
@@ -1,0 +1,48 @@
+﻿#region LICENSE
+// The contents of this file are subject to the Common Public Attribution
+// License Version 1.0. (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// https://github.com/NiclasOlofsson/MiNET/blob/master/LICENSE. 
+// The License is based on the Mozilla Public License Version 1.1, but Sections 14 
+// and 15 have been added to cover use of software over a computer network and 
+// provide for limited attribution for the Original Developer. In addition, Exhibit A has 
+// been modified to be consistent with Exhibit B.
+// 
+// Software distributed under the License is distributed on an "AS IS" basis,
+// WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+// the specific language governing rights and limitations under the License.
+// 
+// The Original Code is MiNET.
+// 
+// The Original Developer is the Initial Developer.  The Initial Developer of
+// the Original Code is Niclas Olofsson.
+// 
+// All portions of the code written by Niclas Olofsson are Copyright (c) 2014-2018 Niclas Olofsson. 
+// All Rights Reserved.
+#endregion
+
+using MiNET.Worlds;
+
+namespace MiNET.Config.Contracts
+{
+	public interface IWorldConfiguration
+	{
+		GameMode GameMode { get; }
+		Difficulty Difficulty { get; }
+		string WorldProvider { get; }
+		string PCWorldFolder { get; }
+		bool SaveEnabled { get; }
+		int SaveInterval { get; }
+		int UnloadInterval { get; }
+		bool CalculateLights { get; }
+		bool CalculateLightsMakeMovie { get; }
+		bool CheckForSafeSpawn { get; }
+		bool EnableBlockTicking { get; }
+		bool EnableChunkTicking { get; }
+		int ViewDistance { get; }
+		string Seed { get; }
+		string SuperflatOverworldSeed { get; }
+		string SuperflatNetherSeed { get; }
+		string SuperflatTheEndSeed { get; }
+	}
+}

--- a/src/MiNET/MiNET/EduTokenManager.cs
+++ b/src/MiNET/MiNET/EduTokenManager.cs
@@ -30,6 +30,8 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using log4net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Utils;
 using Newtonsoft.Json.Linq;
 
@@ -38,6 +40,7 @@ namespace MiNET
 	public class EduTokenManager
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof(EduTokenManager));
+		private static readonly ISecurityConfiguration SecurityConfig = ConfigurationProvider.Configuration.Security;
 
 		private string _username;
 		private string _password;
@@ -46,8 +49,8 @@ namespace MiNET
 
 		public EduTokenManager()
 		{
-			_username = Config.GetProperty("AAD.username", "");
-			_password = Config.GetProperty("AAD.password", "");
+			_username = SecurityConfig.EduUsername;
+			_password = SecurityConfig.EduPassword;
 
 			if (_username.StartsWith("secure:", StringComparison.InvariantCultureIgnoreCase) && _password.StartsWith("secure:", StringComparison.InvariantCultureIgnoreCase))
 			{

--- a/src/MiNET/MiNET/Entities/Behaviors/PathFinder.cs
+++ b/src/MiNET/MiNET/Entities/Behaviors/PathFinder.cs
@@ -34,6 +34,8 @@ using AStarNavigator.Algorithms;
 using AStarNavigator.Providers;
 using log4net;
 using MiNET.Blocks;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Particles;
 using MiNET.Utils;
 using MiNET.Worlds;
@@ -148,6 +150,7 @@ namespace MiNET.Entities.Behaviors
 	{
 		public List<Tile> Current { get; set; } = new List<Tile>();
 		private Dictionary<Tile, Block> _blockCache;
+		private static readonly IGameRuleConfiguration Config = ConfigurationProvider.Configuration.GameRules;
 
 		public Path(Dictionary<Tile, Block> blockCache = null)
 		{
@@ -171,7 +174,7 @@ namespace MiNET.Entities.Behaviors
 
 		public void PrintPath(Level level)
 		{
-			if (Config.GetProperty("Pathfinder.PrintPath", false))
+			if (Config.PathFinderPrintPath)
 			{
 				foreach (var tile in Current)
 				{
@@ -186,7 +189,7 @@ namespace MiNET.Entities.Behaviors
 
 		public void PrintTile(Level level, Tile tile)
 		{
-			if (Config.GetProperty("Pathfinder.PrintPath", false))
+			if (Config.PathFinderPrintPath)
 			{
 				Block block = GetBlock(tile);
 				var particle = new RedstoneParticle(level);

--- a/src/MiNET/MiNET/LevelManager.cs
+++ b/src/MiNET/MiNET/LevelManager.cs
@@ -28,6 +28,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using log4net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Utils;
 using MiNET.Worlds;
 
@@ -36,6 +38,7 @@ namespace MiNET
 	public class LevelManager
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof(LevelManager));
+		private static readonly IConfiguration Config = ConfigurationProvider.Configuration;
 
 		public List<Level> Levels { get; set; } = new List<Level>();
 
@@ -50,13 +53,13 @@ namespace MiNET
 			Level level = Levels.FirstOrDefault(l => l.LevelId.Equals(name, StringComparison.InvariantCultureIgnoreCase));
 			if (level == null)
 			{
-				GameMode gameMode = Config.GetProperty("GameMode", GameMode.Survival);
-				Difficulty difficulty = Config.GetProperty("Difficulty", Difficulty.Normal);
-				int viewDistance = Config.GetProperty("ViewDistance", 11);
+				GameMode gameMode = Config.World.GameMode;
+				Difficulty difficulty = Config.World.Difficulty;
+				int viewDistance = Config.World.ViewDistance;
 
 				IWorldProvider worldProvider = null;
 
-				switch (Config.GetProperty("WorldProvider", "anvil").ToLower().Trim())
+				switch (Config.World.WorldProvider.ToLower().Trim())
 				{
 					case "cool":
 						worldProvider = new CoolWorldProvider();
@@ -71,50 +74,50 @@ namespace MiNET
 						worldProvider = new AnvilWorldProvider
 						{
 							MissingChunkProvider = new SuperflatGenerator(Dimension.Overworld),
-							ReadSkyLight = !Config.GetProperty("CalculateLights", false),
-							ReadBlockLight = !Config.GetProperty("CalculateLights", false),
+							ReadSkyLight = !Config.World.CalculateLights,
+							ReadBlockLight = !Config.World.CalculateLights,
 						};
 						break;
 				}
 
 				level = new Level(this, name, worldProvider, EntityManager, gameMode, difficulty, viewDistance)
 				{
-					EnableBlockTicking = Config.GetProperty("EnableBlockTicking", false),
-					EnableChunkTicking = Config.GetProperty("EnableChunkTicking", false),
-					SaveInterval = Config.GetProperty("Save.Interval", 300),
-					UnloadInterval = Config.GetProperty("Unload.Interval", -1),
+					EnableBlockTicking = Config.World.EnableBlockTicking,
+					EnableChunkTicking = Config.World.EnableChunkTicking,
+					SaveInterval = Config.World.SaveInterval,
+					UnloadInterval = Config.World.UnloadInterval,
 
-					DrowningDamage = Config.GetProperty("GameRule.DrowningDamage", true),
-					CommandblockOutput = Config.GetProperty("GameRule.CommandblockOutput", true),
-					DoTiledrops = Config.GetProperty("GameRule.DoTiledrops", true),
-					DoMobloot = Config.GetProperty("GameRule.DoMobloot", true),
-					KeepInventory = Config.GetProperty("GameRule.KeepInventory", true),
-					DoDaylightcycle = Config.GetProperty("GameRule.DoDaylightcycle", true),
-					DoMobspawning = Config.GetProperty("GameRule.DoMobspawning", true),
-					DoEntitydrops = Config.GetProperty("GameRule.DoEntitydrops", true),
-					DoFiretick = Config.GetProperty("GameRule.DoFiretick", true),
-					DoWeathercycle = Config.GetProperty("GameRule.DoWeathercycle", true),
-					Pvp = Config.GetProperty("GameRule.Pvp", true),
-					Falldamage = Config.GetProperty("GameRule.Falldamage", true),
-					Firedamage = Config.GetProperty("GameRule.Firedamage", true),
-					Mobgriefing = Config.GetProperty("GameRule.Mobgriefing", true),
-					ShowCoordinates = Config.GetProperty("GameRule.ShowCoordinates", true),
-					NaturalRegeneration = Config.GetProperty("GameRule.NaturalRegeneration", true),
-					TntExplodes = Config.GetProperty("GameRule.TntExplodes", true),
-					SendCommandfeedback = Config.GetProperty("GameRule.SendCommandfeedback", true),
-					RandomTickSpeed = Config.GetProperty("GameRule.RandomTickSpeed", 3),
+					DrowningDamage = Config.GameRules.DrowningDamage,
+					CommandblockOutput = Config.GameRules.CommandBlockOutput,
+					DoTiledrops = Config.GameRules.DoTiledrops,
+					DoMobloot = Config.GameRules.DoMobloot,
+					KeepInventory = Config.GameRules.KeepInventory,
+					DoDaylightcycle = Config.GameRules.DoDaylightcycle,
+					DoMobspawning = Config.GameRules.DoMobSpawning,
+					DoEntitydrops = Config.GameRules.DoEntitydrops,
+					DoFiretick = Config.GameRules.DoFiretick,
+					DoWeathercycle = Config.GameRules.DoWeathercycle,
+					Pvp = Config.GameRules.Pvp,
+					Falldamage = Config.GameRules.Falldamage,
+					Firedamage = Config.GameRules.Firedamage,
+					Mobgriefing = Config.GameRules.Mobgriefing,
+					ShowCoordinates = Config.GameRules.ShowCoordinates,
+					NaturalRegeneration = Config.GameRules.NaturalRegeneration,
+					TntExplodes = Config.GameRules.TntExplodes,
+					SendCommandfeedback = Config.GameRules.SendCommandfeedback,
+					RandomTickSpeed = Config.GameRules.RandomTickSpeed,
 				};
 				level.Initialize();
 
-				//if (Config.GetProperty("CalculateLights", false))
+				//if (_config.World.CalculateLights)
 				//{
 				//	{
 				//		AnvilWorldProvider wp = level.WorldProvider as AnvilWorldProvider;
 				//		if (wp != null)
 				//		{
 				//			wp.Locked = true;
-				////			wp.PruneAir();
-				////			wp.MakeAirChunksAroundWorldToCompensateForBadRendering();
+				//			//			wp.PruneAir();
+				//			//			wp.MakeAirChunksAroundWorldToCompensateForBadRendering();
 				//			Stopwatch sw = new Stopwatch();
 
 				//			var chunkCount = 0;
@@ -216,7 +219,7 @@ namespace MiNET
 
 			newLevel.Initialize();
 
-			//if (Config.GetProperty("CalculateLights", false))
+			//if (_config.World.CalculateLights)
 			//{
 			//	worldProvider.Locked = true;
 			//	SkyLightCalculations.Calculate(newLevel);
@@ -228,7 +231,7 @@ namespace MiNET
 			//	RecalculateBlockLight(newLevel, worldProvider);
 
 			//	var chunkCount = worldProvider._chunkCache.Where(chunk => chunk.Value != null).ToArray().Length;
-			//	Log.Debug($"Recalc sky and block light for {chunkCount} chunks, {chunkCount*16*16*256} blocks and {count} light sources. Time {sw.ElapsedMilliseconds}ms");
+			//	Log.Debug($"Recalc sky and block light for {chunkCount} chunks, {chunkCount * 16 * 16 * 256} blocks and {count} light sources. Time {sw.ElapsedMilliseconds}ms");
 			//	worldProvider.Locked = false;
 			//}
 
@@ -239,6 +242,7 @@ namespace MiNET
 	public class SpreadLevelManager : LevelManager
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof(SpreadLevelManager));
+		private static readonly IWorldConfiguration WorldConfig = ConfigurationProvider.Configuration.World;
 
 		private readonly int _numberOfLevels;
 
@@ -270,9 +274,9 @@ namespace MiNET
 
 		public virtual Level CreateLevel(string name, IWorldProvider provider)
 		{
-			GameMode gameMode = Config.GetProperty("GameMode", GameMode.Survival);
-			Difficulty difficulty = Config.GetProperty("Difficulty", Difficulty.Peaceful);
-			int viewDistance = Config.GetProperty("ViewDistance", 11);
+			GameMode gameMode = WorldConfig.GameMode;
+			Difficulty difficulty = WorldConfig.Difficulty;
+			int viewDistance = WorldConfig.ViewDistance;
 
 			IWorldProvider worldProvider = null;
 			worldProvider = provider ?? new AnvilWorldProvider {MissingChunkProvider = new SuperflatGenerator(Dimension.Overworld)};

--- a/src/MiNET/MiNET/LoginMessageHandler.cs
+++ b/src/MiNET/MiNET/LoginMessageHandler.cs
@@ -33,6 +33,8 @@ using System.Text;
 using fNbt;
 using Jose;
 using log4net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Net;
 using MiNET.Utils;
 using MiNET.Utils.Skins;
@@ -51,6 +53,7 @@ namespace MiNET
 	public class LoginMessageHandler : IMcpeMessageHandler
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof(LoginMessageHandler));
+		private static readonly ISecurityConfiguration SecurityConfig = ConfigurationProvider.Configuration.Security;
 
 		private readonly PlayerNetworkSession _session;
 
@@ -306,7 +309,7 @@ namespace MiNET
 
 						_session.CryptoContext = new CryptoContext
 						{
-							UseEncryption = Config.GetProperty("UseEncryptionForAll", false) || (Config.GetProperty("UseEncryption", true) && !string.IsNullOrWhiteSpace(_playerInfo.CertificateData.ExtraData.Xuid)),
+							UseEncryption = SecurityConfig.UseEncryptionForAll || SecurityConfig.UseEncryption && !string.IsNullOrWhiteSpace(_playerInfo.CertificateData.ExtraData.Xuid)
 						};
 
 #if LINUX
@@ -424,10 +427,10 @@ namespace MiNET
 				return;
 			}
 
-			if (Config.GetProperty("ForceXBLAuthentication", false) && _playerInfo.CertificateData.ExtraData.Xuid == null)
+			if (SecurityConfig.ForceXBLAuthentication && _playerInfo.CertificateData.ExtraData.Xuid == null)
 			{
 				Log.Warn($"You must authenticate to XBOX Live to join this server.");
-				_session.Disconnect(Config.GetProperty("ForceXBLLogin", "You must authenticate to XBOX Live to join this server."));
+				_session.Disconnect(SecurityConfig.ForceXBLLogin);
 
 				return;
 			}

--- a/src/MiNET/MiNET/MotdProvider.cs
+++ b/src/MiNET/MiNET/MotdProvider.cs
@@ -24,6 +24,8 @@
 #endregion
 
 using System.Net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Net;
 using MiNET.Utils;
 
@@ -31,6 +33,7 @@ namespace MiNET
 {
 	public class MotdProvider
 	{
+		private static readonly IServerConfiguration ServerConfig = ConfigurationProvider.Configuration.Server;
 		public string Motd { get; set; }
 
 		public string SecondLine { get; set; }
@@ -41,8 +44,8 @@ namespace MiNET
 
 		public MotdProvider()
 		{
-			Motd = Config.GetProperty("motd", "MiNET: MCPE Server");
-			SecondLine = Config.GetProperty("motd-2nd", "MiNET");
+			Motd = ServerConfig.Motd;
+			SecondLine = ServerConfig.MotdSecond;
 		}
 
 		public virtual string GetMotd(ServerInfo serverInfo, IPEndPoint caller, bool eduMotd = false)

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -34,6 +34,8 @@ using System.Numerics;
 using System.Threading;
 using log4net;
 using MiNET.Blocks;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Crafting;
 using MiNET.Effects;
 using MiNET.Entities;
@@ -53,6 +55,7 @@ namespace MiNET
 	public class Player : Entity, IMcpeMessageHandler
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof(Player));
+		private static readonly IPlayerConfiguration PlayerConfig = ConfigurationProvider.Configuration.Player;
 
 		private MiNetServer Server { get; set; }
 		public IPEndPoint EndPoint { get; private set; }
@@ -800,7 +803,7 @@ namespace MiNET
 
 				Level.EntityManager.AddEntity(this);
 
-				GameMode = Config.GetProperty("Player.GameMode", Level.GameMode);
+				GameMode = PlayerConfig.PlayerGameMode;
 
 				//
 				// Start game - spawn sequence starts here
@@ -860,7 +863,7 @@ namespace MiNET
 			Log.InfoFormat("Login complete by: {0} from {2} in {1}ms", Username, watch.ElapsedMilliseconds, EndPoint);
 		}
 
-		public bool EnableCommands { get; set; } = Config.GetProperty("EnableCommands", false);
+		public bool EnableCommands { get; set; } = PlayerConfig.EnableCommands;
 
 		protected virtual void SendSetCommandsEnabled()
 		{

--- a/src/MiNET/MiNET/PlayerFactory.cs
+++ b/src/MiNET/MiNET/PlayerFactory.cs
@@ -1,16 +1,19 @@
 using System;
 using System.Net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Utils;
 
 namespace MiNET
 {
 	public class PlayerFactory
 	{
+		private static readonly IPlayerConfiguration PlayerConfig = ConfigurationProvider.Configuration.Player;
 		public virtual Player CreatePlayer(MiNetServer server, IPEndPoint endPoint, PlayerInfo playerInfo)
 		{
 			var player = new Player(server, endPoint);
-			player.MaxViewDistance = Config.GetProperty("MaxViewDistance", 22);
-			player.MoveRenderDistance = Config.GetProperty("MoveRenderDistance", 1);
+			player.MaxViewDistance = PlayerConfig.MaxViewDistance;
+			player.MoveRenderDistance = PlayerConfig.MoveRenderDistance;
 			OnPlayerCreated(new PlayerEventArgs(player));
 			return player;
 		}

--- a/src/MiNET/MiNET/Plugins/Attributes/AuthorizeAttribute.cs
+++ b/src/MiNET/MiNET/Plugins/Attributes/AuthorizeAttribute.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Net;
 using MiNET.Utils;
 
@@ -7,7 +9,9 @@ namespace MiNET.Plugins.Attributes
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
 	public class AuthorizeAttribute : Attribute
 	{
+		private static readonly IServerConfiguration ServerConfig = ConfigurationProvider.Configuration.Server;
+
 		public int Permission { get; set; } = (int) CommandPermission.Normal;
-		public string ErrorMessage { get; set; } = Config.GetProperty("Authorize.ErrorMessage", "§cInsufficient permissions. Requires {1}, but player had {0}");
+		public string ErrorMessage { get; set; } = ServerConfig.AuthorizeErrorMessage;
 	}
 }

--- a/src/MiNET/MiNET/Plugins/Commands/VanillaCommands.cs
+++ b/src/MiNET/MiNET/Plugins/Commands/VanillaCommands.cs
@@ -29,6 +29,8 @@ using System.Linq;
 using System.Numerics;
 using System.Threading;
 using log4net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Entities;
 using MiNET.Entities.Hostile;
 using MiNET.Entities.Passive;
@@ -44,6 +46,7 @@ namespace MiNET.Plugins.Commands
 	public class VanillaCommands
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof (VanillaCommands));
+		private static readonly ISecurityConfiguration SecurityConfig = ConfigurationProvider.Configuration.Security;
 
 		public VanillaCommands()
 		{
@@ -290,7 +293,7 @@ namespace MiNET.Plugins.Commands
 					mob = new Vex(world);
 					break;
 				case EntityType.Npc:
-					if (Config.GetProperty("EnableEdu", false))
+					if (SecurityConfig.EnableEdu)
 					{
 						mob = new Npc(world);
 					}

--- a/src/MiNET/MiNET/Utils/CryptoUtils.cs
+++ b/src/MiNET/MiNET/Utils/CryptoUtils.cs
@@ -35,6 +35,8 @@ using System.Threading;
 using JetBrains.Annotations;
 using Jose;
 using log4net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Net;
 using MiNET.Utils.Skins;
 using Org.BouncyCastle.Asn1;
@@ -49,6 +51,7 @@ namespace MiNET.Utils
 	public static class CryptoUtils
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof (CryptoUtils));
+		private static readonly ISecurityConfiguration SecurityConfig = ConfigurationProvider.Configuration.Security;
 
 		public static byte[] DecodeBase64Url(this string input)
 		{
@@ -246,7 +249,7 @@ namespace MiNET.Utils
 	""DeviceModel"": ""MINET CLIENT"",
 	""DeviceOS"": 7,
 	""GameVersion"": ""{McpeProtocolInfo.GameVersion}"",
-	""IsEduMode"": {Config.GetProperty("EnableEdu", false).ToString().ToLower()},
+	""IsEduMode"": {SecurityConfig.EnableEdu.ToString().ToLower()},
 	""GuiScale"": 0,
 	""LanguageCode"": ""en_US"",
 	""PlatformOfflineId"": """",

--- a/src/MiNET/MiNET/Utils/Diagnostics/Profiler.cs
+++ b/src/MiNET/MiNET/Utils/Diagnostics/Profiler.cs
@@ -30,6 +30,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using log4net;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 
 namespace MiNET.Utils.Diagnostics
 {
@@ -43,13 +45,14 @@ namespace MiNET.Utils.Diagnostics
 	/// </summary>
 	public class Profiler
 	{
+		private static readonly IDebugConfiguration DebugConfig = ConfigurationProvider.Configuration.Debug;
 		public bool Enabled { get; set; }
 
 		ConcurrentBag<ProfilerResult> _results = new ConcurrentBag<ProfilerResult>();
 
 		public Profiler()
 		{
-			Enabled = Config.GetProperty("Profiler.Enabled", false);
+			Enabled = DebugConfig.ProfilerEnabled;
 		}
 
 		public Measurement Begin(string name)

--- a/src/MiNET/MiNET/Worlds/AnvilWorldProvider.cs
+++ b/src/MiNET/MiNET/Worlds/AnvilWorldProvider.cs
@@ -37,6 +37,8 @@ using fNbt;
 using log4net;
 using MiNET.BlockEntities;
 using MiNET.Blocks;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Items;
 using MiNET.Net;
 using MiNET.Utils;
@@ -61,6 +63,7 @@ namespace MiNET.Worlds
 	public class AnvilWorldProvider : IWorldProvider, ICachingWorldProvider, ICloneable
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof(AnvilWorldProvider));
+		private static readonly IWorldConfiguration WorldConfig = ConfigurationProvider.Configuration.World;
 
 		public static readonly Dictionary<int, Tuple<int, Func<int, byte, byte>>> Convert;
 
@@ -229,7 +232,7 @@ namespace MiNET.Worlds
 			{
 				if (_isInitialized) return;
 
-				BasePath = BasePath ?? Config.GetProperty("PCWorldFolder", "World").Trim();
+				BasePath = BasePath ?? WorldConfig.PCWorldFolder.Trim();
 
 				NbtFile file = new NbtFile();
 				var levelFileName = Path.Combine(BasePath, "level.dat");
@@ -287,7 +290,7 @@ namespace MiNET.Worlds
 					if (!coords.Contains(chunkCoordinates)) coords.Add(chunkCoordinates);
 				}
 
-				bool save = Config.GetProperty("Save.Enabled", false);
+				bool save = WorldConfig.SaveEnabled;
 
 				Parallel.ForEach(_chunkCache, (chunkColumn) =>
 				{
@@ -359,7 +362,7 @@ namespace MiNET.Worlds
 					var chunkColumn = generator?.GenerateChunkColumn(coordinates);
 					if (chunkColumn != null)
 					{
-						if (Dimension == Dimension.Overworld && Config.GetProperty("CalculateLights", false))
+						if (Dimension == Dimension.Overworld && WorldConfig.CalculateLights)
 						{
 							SkyLightBlockAccess blockAccess = new SkyLightBlockAccess(this, chunkColumn);
 							new SkyLightCalculations().RecalcSkyLight(chunkColumn, blockAccess);
@@ -405,7 +408,7 @@ namespace MiNET.Worlds
 						var chunkColumn = generator?.GenerateChunkColumn(coordinates);
 						if (chunkColumn != null)
 						{
-							if (Dimension == Dimension.Overworld && Config.GetProperty("CalculateLights", false))
+							if (Dimension == Dimension.Overworld && WorldConfig.CalculateLights)
 							{
 								SkyLightBlockAccess blockAccess = new SkyLightBlockAccess(this, chunkColumn);
 								new SkyLightCalculations().RecalcSkyLight(chunkColumn, blockAccess);
@@ -583,7 +586,7 @@ namespace MiNET.Worlds
 
 					chunk.RecalcHeight();
 
-					if (Dimension == Dimension.Overworld && Config.GetProperty("CalculateLights", false))
+					if (Dimension == Dimension.Overworld && WorldConfig.CalculateLights)
 					{
 						SkyLightBlockAccess blockAccess = new SkyLightBlockAccess(this, chunk);
 						new SkyLightCalculations().RecalcSkyLight(chunk, blockAccess);
@@ -776,7 +779,7 @@ namespace MiNET.Worlds
 
 		public int SaveChunks()
 		{
-			if (!Config.GetProperty("Save.Enabled", false)) return 0;
+			if (!WorldConfig.SaveEnabled) return 0;
 
 			int count = 0;
 			try

--- a/src/MiNET/MiNET/Worlds/CoolWorldProvider.cs
+++ b/src/MiNET/MiNET/Worlds/CoolWorldProvider.cs
@@ -28,6 +28,8 @@ using System.Collections.Concurrent;
 using System.Numerics;
 using LibNoise;
 using LibNoise.Primitive;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Utils;
 using MiNET.Worlds.Structures;
 
@@ -111,7 +113,8 @@ namespace MiNET.Worlds
 
 	public class CoolWorldProvider : IWorldProvider
 	{
-		private string _seed = Config.GetProperty("seed", "noise");
+		private static readonly  IWorldConfiguration WorldConfig = ConfigurationProvider.Configuration.World;
+		private string _seed = WorldConfig.Seed;
 		private readonly ConcurrentDictionary<ChunkCoordinates, ChunkColumn> _chunkCache = new ConcurrentDictionary<ChunkCoordinates, ChunkColumn>();
 		public bool IsCaching { get; private set; }
 

--- a/src/MiNET/MiNET/Worlds/Level.cs
+++ b/src/MiNET/MiNET/Worlds/Level.cs
@@ -36,6 +36,8 @@ using fNbt;
 using log4net;
 using MiNET.BlockEntities;
 using MiNET.Blocks;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Entities;
 using MiNET.Entities.Hostile;
 using MiNET.Entities.Passive;
@@ -51,6 +53,7 @@ namespace MiNET.Worlds
 	public class Level : IBlockAccess
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof (Level));
+		private static readonly IWorldConfiguration WorldConfig = ConfigurationProvider.Configuration.World;
 
 		public static readonly BlockCoordinates Up = new BlockCoordinates(0, 1, 0);
 		public static readonly BlockCoordinates Down = new BlockCoordinates(0, -1, 0);
@@ -154,7 +157,7 @@ namespace MiNET.Worlds
 
 			if (Dimension == Dimension.Overworld)
 			{
-				if (Config.GetProperty("CheckForSafeSpawn", false))
+				if (WorldConfig.CheckForSafeSpawn)
 				{
 					var height = GetHeight((BlockCoordinates) SpawnPoint);
 					if (height > SpawnPoint.Y) SpawnPoint.Y = height;

--- a/src/MiNET/MiNET/Worlds/SkyLightCalculations.cs
+++ b/src/MiNET/MiNET/Worlds/SkyLightCalculations.cs
@@ -35,6 +35,8 @@ using System.Numerics;
 using System.Threading.Tasks;
 using log4net;
 using MiNET.Blocks;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Utils;
 using SharpAvi;
 using SharpAvi.Output;
@@ -114,6 +116,7 @@ namespace MiNET.Worlds
 	public class SkyLightCalculations
 	{
 		private static readonly ILog Log = LogManager.GetLogger(typeof (SkyLightCalculations));
+		private static readonly IWorldConfiguration WorldConfig = ConfigurationProvider.Configuration.World;
 
 		// Debug tracking, don't enable unless you really need to "see it".
 
@@ -148,7 +151,7 @@ namespace MiNET.Worlds
 
 			//Log.Debug($"Recalc height level {level.LevelName}({level.LevelId}) for {_chunkCount} chunks, {_chunkCount*16*16*256} blocks. Time {sw.ElapsedMilliseconds}ms");
 
-			SkyLightCalculations calculator = new SkyLightCalculations(Config.GetProperty("CalculateLights.MakeMovie", false));
+			SkyLightCalculations calculator = new SkyLightCalculations(WorldConfig.CalculateLightsMakeMovie);
 
 			int midX = calculator.GetMidX(chunks.ToArray());
 			//int width = calculator.GetWidth(chunks.ToArray());

--- a/src/MiNET/MiNET/Worlds/SuperflatGenerator.cs
+++ b/src/MiNET/MiNET/Worlds/SuperflatGenerator.cs
@@ -27,12 +27,15 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using MiNET.Blocks;
+using MiNET.Config;
+using MiNET.Config.Contracts;
 using MiNET.Utils;
 
 namespace MiNET.Worlds
 {
 	public class SuperflatGenerator : IWorldGenerator
 	{
+		private static readonly IWorldConfiguration WorldConfig = ConfigurationProvider.Configuration.World;
 		public string Seed { get; set; }
 		public List<Block> BlockLayers { get; set; }
 		public Dimension Dimension { get; set; }
@@ -43,13 +46,13 @@ namespace MiNET.Worlds
 			switch (dimension)
 			{
 				case Dimension.Overworld:
-					Seed = Config.GetProperty("superflat.overworld", "3;minecraft:bedrock,2*minecraft:dirt,minecraft:grass;1;village");
+					Seed = WorldConfig.SuperflatOverworldSeed;
 					break;
 				case Dimension.Nether:
-					Seed = Config.GetProperty("superflat.nether", "3;minecraft:bedrock,2*minecraft:netherrack,3*minecraft:lava,2*minecraft:netherrack,20*minecraft:air,minecraft:bedrock;1;village");
+					Seed = WorldConfig.SuperflatNetherSeed;
 					break;
 				case Dimension.TheEnd:
-					Seed = Config.GetProperty("superflat.theend", "3;40*minecraft:air,minecraft:bedrock,7*minecraft:endstone;1;village");
+					Seed = WorldConfig.SuperflatTheEndSeed;
 					break;
 			}
 		}


### PR DESCRIPTION
The way config key strings and defaults were hamfisted (and sometimes repeated) all over the codebase didn't seem very elegant to me, so I've abstracted it into a couple of interfaces and moved all the parsing/implementation business into the MiNET.Console assembly.

I've also grouped it into logical blocks for better readability and usability.