### PR TITLE
PlayerFactory: Use object initializer syntax

### DIFF
--- a/src/MiNET/MiNET/PlayerFactory.cs
+++ b/src/MiNET/MiNET/PlayerFactory.cs
@@ -8,9 +8,11 @@ namespace MiNET
 	{
 		public virtual Player CreatePlayer(MiNetServer server, IPEndPoint endPoint, PlayerInfo playerInfo)
 		{
-			var player = new Player(server, endPoint);
-			player.MaxViewDistance = Config.GetProperty("MaxViewDistance", 22);
-			player.MoveRenderDistance = Config.GetProperty("MoveRenderDistance", 1);
+			var player = new Player(server, endPoint)
+			{
+				MaxViewDistance = Config.GetProperty("MaxViewDistance", 22),
+				MoveRenderDistance = Config.GetProperty("MoveRenderDistance", 1)
+			};
 			OnPlayerCreated(new PlayerEventArgs(player));
 			return player;
 		}


### PR DESCRIPTION
This is an aesthetic improvement, apparently, the object initializer syntax is used everywhere but here.