### PR TITLE
Update Player.cs

### DIFF
--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -2191,7 +2191,7 @@ namespace MiNET
 			{
 				case McpeInventoryTransaction.ItemReleaseAction.Release:
 				{
-					if (_itemUseTimer <= 0) return;
+					if (_itemUseTimer <= 0) break;
 
 					itemInHand.Release(Level, this, transaction.FromPosition, Level.TickTime - _itemUseTimer);
 


### PR DESCRIPTION
Quickly aiming and releasing a bow causes transaction problems as the return statement prevents the call to HandleNormalTransactions(). Replaced with a break statement.