### PR TITLE
Add null-conditional check when attempting to disable plugins

### DIFF
--- a/src/MiNET/MiNET/MiNetServer.cs
+++ b/src/MiNET/MiNET/MiNetServer.cs
@@ -260,7 +260,7 @@ namespace MiNET
 			try
 			{
 				Log.Info("Disabling plugins...");
-				PluginManager.DisablePlugins();
+				PluginManager?.DisablePlugins();
 
 				Log.Info("Shutting down...");
 				if (_listener == null) return true; // Already stopped. It's ok.


### PR DESCRIPTION
If the server is started with a proxy role it would error here during a shutdown, now we make sure the plugin manager is set before trying to disable plugins.