### PR TITLE
Ensure a players network handler is PlayerNetworkSession before trying to send queue

### DIFF
--- a/src/MiNET/MiNET/Worlds/Level.cs
+++ b/src/MiNET/MiNET/Worlds/Level.cs
@@ -673,8 +673,10 @@ namespace MiNET.Worlds
 
 				Parallel.ForEach(players, (player, state) =>
 				{
-					var session = (PlayerNetworkSession) player.NetworkHandler;
-					session?.SendQueue();
+					if (player.NetworkHandler is PlayerNetworkSession session)
+					{
+						session.SendQueue();
+					}
 				});
 
 


### PR DESCRIPTION
This previously errored when trying to tick a level with a player who had a network handler that wasn't a PlayerNetworkSession. This pull request ensures the type (contract) specified on Player.NetworkHandler field is upheld by not assuming it's type to differ from that of INetworkHandler.