### PR TITLE
Fixed bossbar

### DIFF
--- a/src/MiNET/MiNET/Net/McpeBossEvent.cs
+++ b/src/MiNET/MiNET/Net/McpeBossEvent.cs
@@ -1,4 +1,4 @@
-#region LICENSE
+﻿#region LICENSE
 
 // The contents of this file are subject to the Common Public Attribution
 // License Version 1.0. (the "License"); you may not use this file except in
@@ -28,6 +28,8 @@ namespace MiNET.Net
 	public partial class McpeBossEvent
 	{
 		public ushort unknown6;
+		public string title;
+		public float healthPercent;
 
 		partial void AfterEncode()
 		{
@@ -39,14 +41,16 @@ namespace MiNET.Net
 					break;
 				case 4:
 					// float
+					Write(healthPercent);
 					break;
 				case 5:
 					// string
+					Write(title);
 					break;
 				case 0:
-					// string
-					// float
-					break;
+					Write(title);
+					Write(healthPercent);
+					goto case 6;
 				case 6:
 					// ushort?
 					Write(unknown6);

--- a/src/MiNET/TestPlugin/CoreCommands.cs
+++ b/src/MiNET/TestPlugin/CoreCommands.cs
@@ -88,6 +88,19 @@ namespace TestPlugin
 		{
 		}
 
+		[Command(Name = "bossbar")]
+		public void BossbarCommand(Player player )
+		{
+			var bossBar = new BossBar(player.Level)
+			{
+				Animate = false,
+				MaxProgress = 10,
+				Progress = 10,
+				NameTag = $"{ChatColors.Gold}You are playing on a {ChatColors.Gold}MiNET{ChatColors.Gold} server"
+			};
+			bossBar.SpawnEntity();
+		}
+
 		[Command(Name = "pe", Description = "Particle effects!")]
 		public void ParticleEffect(Player player, string particle)
 		{


### PR DESCRIPTION
- It was possible to hit slime mob before
- It wasn't invisible
- It wasn't working on 1.11 🙂