### PR TITLE
Add CraftRecipeOptional action type

### DIFF
--- a/src/MiNET/MiNET/ItemStackInventoryManager.cs
+++ b/src/MiNET/MiNET/ItemStackInventoryManager.cs
@@ -67,6 +67,11 @@ namespace MiNET
 						ProcessCraftNotImplementedDeprecatedAction(craftNotImplementedDeprecatedAction);
 						break;
 					}
+					case CraftRecipeOptionalAction craftRecipeOptionalAction:
+					{
+						ProcessCraftRecipeOptionalAction(craftRecipeOptionalAction);
+						break;
+					}
 					case CraftResultDeprecatedAction craftResultDeprecatedAction:
 					{
 						ProcessCraftResultDeprecatedAction(craftResultDeprecatedAction);
@@ -452,6 +457,10 @@ namespace MiNET
 			creativeItem.UniqueId = Environment.TickCount;
 			Log.Debug($"Creating {creativeItem}");
 			_player.Inventory.UiInventory.Slots[50] = creativeItem;
+		}
+
+		protected virtual void ProcessCraftRecipeOptionalAction(CraftRecipeOptionalAction action)
+		{
 		}
 
 		private Item GetContainerItem(int containerId, int slot)

--- a/src/MiNET/MiNET/LoginMessageHandler.cs
+++ b/src/MiNET/MiNET/LoginMessageHandler.cs
@@ -717,6 +717,10 @@ namespace MiNET
 		public void HandleMcpeScriptCustomEvent(McpeScriptCustomEvent message)
 		{
 		}
+
+		public void HandleMcpeFilterText(McpeFilterTextPacket message)
+		{
+		}
 	}
 
 	public interface IServerManager

--- a/src/MiNET/MiNET/Net/BedrockMessageHandler.cs
+++ b/src/MiNET/MiNET/Net/BedrockMessageHandler.cs
@@ -228,6 +228,9 @@ namespace MiNET.Net
 				case McpePlayerSkin msg:
 					handler.HandleMcpePlayerSkin(msg);
 					break;
+				case McpeFilterTextPacket msg:
+					handler.HandleMcpeFilterText(msg);
+					break;
 
 				default:
 				{

--- a/src/MiNET/MiNET/Net/MCPE Protocol.cs
+++ b/src/MiNET/MiNET/Net/MCPE Protocol.cs
@@ -104,6 +104,7 @@ namespace MiNET.Net
 		void HandleMcpeItemStackRequest(McpeItemStackRequest message);
 		void HandleMcpeUpdatePlayerGameType(McpeUpdatePlayerGameType message);
 		void HandleMcpePacketViolationWarning(McpePacketViolationWarning message);
+		void HandleMcpeFilterText(McpeFilterTextPacket message);
 	}
 
 	public interface IMcpeClientMessageHandler
@@ -9660,8 +9661,9 @@ namespace MiNET.Net
 			CraftRecipe = 9,
 			CraftRecipeAuto = 10,
 			CraftCreative = 11,
-			CraftNotImplementedDeprecated = 12,
-			CraftResultsDeprecated = 13,
+			CraftRecipeOptional = 12,
+			CraftNotImplementedDeprecated = 13,
+			CraftResultsDeprecated = 14,
 		}
 
 		public ItemStackRequests requests; // = null;

--- a/src/MiNET/MiNET/Net/Packet.cs
+++ b/src/MiNET/MiNET/Net/Packet.cs
@@ -1176,6 +1176,14 @@ namespace MiNET.Net
 							break;
 						}
 
+						case CraftRecipeOptionalAction ta:
+						{
+							Write((byte) McpeItemStackRequest.ActionType.CraftRecipeOptional);
+							WriteUnsignedVarInt(ta.RecipeNetworkId);
+							Write(ta.FilteredStringIndex);
+							break;
+						}
+
 						case CraftNotImplementedDeprecatedAction ta:
 						{
 							Write((byte) McpeItemStackRequest.ActionType.CraftNotImplementedDeprecated);
@@ -1206,8 +1214,9 @@ namespace MiNET.Net
 		//public const CRAFTING_RECIPE = 9;
 		//public const CRAFTING_RECIPE_AUTO = 10; //recipe book?
 		//public const CREATIVE_CREATE = 11;
-		//public const CRAFTING_NON_IMPLEMENTED_DEPRECATED_ASK_TY_LAING = 12; //anvils aren't fully implemented yet
-		//public const CRAFTING_RESULTS_DEPRECATED_ASK_TY_LAING = 13; //no idea what this is for
+		//public const CRAFT_RECIPE_OPTIONAL = 12;
+		//public const CRAFTING_NON_IMPLEMENTED_DEPRECATED_ASK_TY_LAING = 13; 
+		//public const CRAFTING_RESULTS_DEPRECATED_ASK_TY_LAING = 14; //no idea what this is for
 
 		public ItemStackRequests ReadItemStackRequests()
 		{
@@ -1319,6 +1328,14 @@ namespace MiNET.Net
 						{
 							var action = new CraftCreativeAction();
 							action.CreativeItemNetworkId = ReadUnsignedVarInt();
+							actions.Add(action);
+							break;
+						}
+						case McpeItemStackRequest.ActionType.CraftRecipeOptional:
+						{
+							var action = new CraftRecipeOptionalAction();
+							action.RecipeNetworkId = ReadUnsignedVarInt();
+							action.FilteredStringIndex = ReadInt();
 							actions.Add(action);
 							break;
 						}

--- a/src/MiNET/MiNET/Player.cs
+++ b/src/MiNET/MiNET/Player.cs
@@ -3744,6 +3744,16 @@ namespace MiNET
 		public virtual void HandleMcpeLevelSoundEventV2(McpeLevelSoundEventV2 message)
 		{
 		}
+
+		public void HandleMcpeFilterText(McpeFilterTextPacket message)
+		{
+			// Allow anvil renaming to work - this packet must be sent in response
+			// You could also modify the contents to change the outcome.
+			var packet = McpeFilterTextPacket.CreateObject();
+			packet.text = message.text;
+			packet.fromServer = true;
+			SendPacket(packet);
+		}
 	}
 
 	public class PlayerEventArgs : EventArgs

--- a/src/MiNET/MiNET/Utils/Transaction.cs
+++ b/src/MiNET/MiNET/Utils/Transaction.cs
@@ -119,6 +119,12 @@ namespace MiNET.Utils
 		public uint CreativeItemNetworkId { get; set; }
 	}
 
+	public class CraftRecipeOptionalAction : ItemStackAction
+	{
+		public uint RecipeNetworkId { get; set; }
+		public int FilteredStringIndex { get; set; }
+	}
+
 	public class CraftNotImplementedDeprecatedAction : ItemStackAction
 	{
 		// nothing


### PR DESCRIPTION
This adds the new CraftRecipeOptional action type introduced in 1.16.200, along with the outline to handle it properly. This also adds FilterTextPacket handling, though anvils are still buggy in my testing (if someone wanted to improve on it, here's the groundwork).