### PR TITLE
Run and build fix.

### DIFF
--- a/src/MiNET/MiNET.Console/MiNET.Console.csproj
+++ b/src/MiNET/MiNET.Console/MiNET.Console.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>full</DebugType>

--- a/src/MiNET/MiNET.Console/server.conf
+++ b/src/MiNET/MiNET.Console/server.conf
@@ -34,7 +34,7 @@ Unload.Interval=10
 
 EnableCommands=true
 
-PluginDirectory=../../../../TestPlugin/bin/Debug/net5.0;../../../../MiNET.BuilderBase/bin/Debug/netcoreapp2.1;../../../../MiNET.Plotter/bin/Debug/netcoreapp2.1
+PluginDirectory=../../../../TestPlugin/bin/Debug/net6.0;../../../../MiNET.BuilderBase/bin/Debug/netcoreapp2.1;../../../../MiNET.Plotter/bin/Debug/netcoreapp2.1
 
 #PluginDisabled=true
 NiceLobby.Enabled=false

--- a/src/MiNET/MiNET.Test/MiNETTests.csproj
+++ b/src/MiNET/MiNET.Test/MiNETTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />

--- a/src/MiNET/MiNET/MiNET.csproj
+++ b/src/MiNET/MiNET/MiNET.csproj
@@ -18,6 +18,7 @@
     <LangVersion>latest</LangVersion>
     <NoWarn>1701;1702;1701</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>full</DebugType>
@@ -52,7 +53,7 @@
     <None Remove="Items\r16_to_current_item_map.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="jose-jwt" Version="3.2.0" />
+    <PackageReference Include="jose-jwt" Version="3.1.1" />
     <PackageReference Include="LibNoise.NetStandart" Version="0.2.0" />
     <PackageReference Include="log4net" Version="2.0.13" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />

--- a/src/MiNET/TestPlugin/TestPlugin.csproj
+++ b/src/MiNET/TestPlugin/TestPlugin.csproj
@@ -2,9 +2,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Stripe.net" Version="16.10.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MiNET\MiNET.csproj" />


### PR DESCRIPTION
Restoring removed information about the framework.
The latest jwt packet breaks encryption.
obsolete PluginDirectory path fix.