### PR TITLE
fix itempick up delay and pickup range

### DIFF
--- a/src/MiNET/MiNET/Entities/World/ItemEntity.cs
+++ b/src/MiNET/MiNET/Entities/World/ItemEntity.cs
@@ -29,7 +29,6 @@ using log4net;
 using MiNET.Blocks;
 using MiNET.Items;
 using MiNET.Net;
-using MiNET.Utils;
 using MiNET.Utils.Vectors;
 using MiNET.Worlds;
 
@@ -54,7 +53,7 @@ namespace MiNET.Entities.World
 			Gravity = 0.04;
 			Drag = 0.02;
 
-			PickupDelay = 10;
+			PickupDelay = 25;
 			TimeToLive = 6000;
 
 			HealthManager.IsInvulnerable = true;
@@ -187,13 +186,13 @@ namespace MiNET.Entities.World
 
 
 			if (PickupDelay > 0) return;
-
+			
 			var bbox = GetBoundingBox();
 
 			var players = Level.GetSpawnedPlayers();
 			foreach (var player in players)
 			{
-				if (player.GameMode != GameMode.Spectator && bbox.Intersects(player.GetBoundingBox() + 1))
+				if (player.GameMode != GameMode.Spectator && bbox.Intersects(player.GetBoundingBox().OffsetBy(new Vector3(1, 0.5f, 1))))
 				{
 					if (player.PickUpItem(this))
 					{

--- a/src/MiNET/MiNET/Utils/Vectors/BoundingBox.cs
+++ b/src/MiNET/MiNET/Utils/Vectors/BoundingBox.cs
@@ -119,7 +119,7 @@ namespace MiNET.Utils.Vectors
 
 		public BoundingBox OffsetBy(Vector3 offset)
 		{
-			return new BoundingBox(Min + offset, Max + offset);
+			return new BoundingBox(Min - offset, Max + offset);
 		}
 
 		public Vector3[] GetCorners()


### PR DESCRIPTION
idk why but the tickrate in minet is 50 so 25 is the half normally the tickrate is 20 so the pickup delay should be 10 but in this case 25 i think