### PR TITLE
update MiNET to netstandard2.1

### DIFF
--- a/src/MiNET/MiNET/Entities/ImageProviders/TextMapImageProvider.cs
+++ b/src/MiNET/MiNET/Entities/ImageProviders/TextMapImageProvider.cs
@@ -23,7 +23,6 @@
 
 #endregion
 
-using System.Drawing.Drawing2D;
 using MiNET.Net;
 using MiNET.Utils;
 using SixLabors.Fonts;

--- a/src/MiNET/MiNET/MiNET.csproj
+++ b/src/MiNET/MiNET/MiNET.csproj
@@ -1,100 +1,105 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
-  <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>MiNET</PackageId>
-    <Version>0.0.0</Version>
-    <Authors>gurun</Authors>
-    <Company>Niclas Olofsson</Company>
-    <Description>MiNET - a Minecraft PocketEdition Server</Description>
-    <Copyright>Copyright Niclas Olofsson 2015-2018</Copyright>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/NiclasOlofsson/MiNET/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/NiclasOlofsson/MiNET</PackageProjectUrl>
-    <PackageIconUrl><![CDATA[https://secure.gravatar.com/avatar/2ba5d72bdad85108d14512c4d27ea550?s=128&r=g&d=retro]]></PackageIconUrl>
-    <PackageTags>MiNET Plugin API MCPE Minecraft PocketEdition bedrock</PackageTags>
-    <FileVersion>10.0.0.0</FileVersion>
-    <AssemblyVersion>10.0.0.0</AssemblyVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <LangVersion>latest</LangVersion>
-    <NoWarn>1701;1702;1701</NoWarn>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Blocks\blockstates.json" />
-    <None Remove="Blocks\legacy_id_map.json" />
-    <None Remove="Items\itemstates.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Blocks\blockstates.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Blocks\Data\block_id_map.json" />
-    <EmbeddedResource Include="Blocks\Data\canonical_block_states.nbt" />
-    <EmbeddedResource Include="Blocks\Data\item_id_map.json" />
-    <EmbeddedResource Include="Blocks\Data\legacy_id_map.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Blocks\Data\r12_to_current_block_map.bin" />
-    <EmbeddedResource Include="Items\Data\itemstates.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Items\Data\item_id_map.json" />
-    <EmbeddedResource Include="Items\Data\r16_to_current_item_map.json" />
-    <None Remove="Blocks\canonical_block_states.nbt" />
-    <None Remove="Blocks\block_id_map.json" />
-    <None Remove="Blocks\item_id_map.json" />
-    <None Remove="Blocks\r12_to_current_block_map.bin" />
-    <None Remove="Items\item_id_map.json" />
-    <None Remove="Items\r16_to_current_item_map.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="jose-jwt" Version="3.1.1" />
-    <PackageReference Include="LibNoise.NetStandart" Version="0.2.0" />
-    <PackageReference Include="log4net" Version="2.0.14" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
-    <PackageReference Include="MiNET.astar" Version="1.0.14" />
-    <PackageReference Include="MiNET.fnbt" Version="1.0.22" />
-    <PackageReference Include="MiNET.LevelDB" Version="1.0.36" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-    <PackageReference Include="SharpAvi" Version="3.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="Net\MCPE Protocol.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Net\MCPE Protocol.xml" />
-    <None Update="Net\MCPE Protocol Documentation.tt">
-      <DependentUpon>MCPE Protocol.xml</DependentUpon>
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>MCPE Protocol Documentation.md</LastGenOutput>
-    </None>
-    <None Update="Net\MCPE Protocol Documentation.md">
-      <DependentUpon>MCPE Protocol Documentation.tt</DependentUpon>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-    </None>
-    <None Update="Net\MCPE Protocol.tt">
-      <DependentUpon>MCPE Protocol.xml</DependentUpon>
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>MCPE Protocol.cs</LastGenOutput>
-    </None>
-    <Compile Update="Net\MCPE Protocol.cs">
-      <DependentUpon>MCPE Protocol.tt</DependentUpon>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-  </ItemGroup>
+	<PropertyGroup>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageId>MiNET</PackageId>
+		<Version>0.0.0</Version>
+		<Authors>gurun</Authors>
+		<Company>Niclas Olofsson</Company>
+		<Description>MiNET - a Minecraft PocketEdition Server</Description>
+		<Copyright>Copyright Niclas Olofsson 2015-2018</Copyright>
+		<PackageLicenseUrl>https://raw.githubusercontent.com/NiclasOlofsson/MiNET/master/LICENSE</PackageLicenseUrl>
+		<PackageProjectUrl>https://github.com/NiclasOlofsson/MiNET</PackageProjectUrl>
+		<PackageIconUrl><![CDATA[https://secure.gravatar.com/avatar/2ba5d72bdad85108d14512c4d27ea550?s=128&r=g&d=retro]]></PackageIconUrl>
+		<PackageTags>MiNET Plugin API MCPE Minecraft PocketEdition bedrock</PackageTags>
+		<FileVersion>10.0.0.0</FileVersion>
+		<AssemblyVersion>10.0.0.0</AssemblyVersion>
+	</PropertyGroup>
+	<PropertyGroup>
+		<LangVersion>latest</LangVersion>
+		<NoWarn>1701;1702;1701</NoWarn>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>full</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="Blocks\blockstates.json"/>
+		<None Remove="Blocks\legacy_id_map.json"/>
+		<None Remove="Items\itemstates.json"/>
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="Blocks\blockstates.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<EmbeddedResource Include="Blocks\Data\block_id_map.json"/>
+		<EmbeddedResource Include="Blocks\Data\canonical_block_states.nbt"/>
+		<EmbeddedResource Include="Blocks\Data\item_id_map.json"/>
+		<EmbeddedResource Include="Blocks\Data\legacy_id_map.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<EmbeddedResource Include="Blocks\Data\r12_to_current_block_map.bin"/>
+		<EmbeddedResource Include="Items\Data\itemstates.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<EmbeddedResource Include="Items\Data\item_id_map.json"/>
+		<EmbeddedResource Include="Items\Data\r16_to_current_item_map.json"/>
+		<None Remove="Blocks\canonical_block_states.nbt"/>
+		<None Remove="Blocks\block_id_map.json"/>
+		<None Remove="Blocks\item_id_map.json"/>
+		<None Remove="Blocks\r12_to_current_block_map.bin"/>
+		<None Remove="Items\item_id_map.json"/>
+		<None Remove="Items\r16_to_current_item_map.json"/>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="jose-jwt" Version="3.1.1"/>
+		<PackageReference Include="LibNoise.NetStandart" Version="0.2.0"/>
+		<PackageReference Include="log4net" Version="2.0.14"/>
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0"/>
+		<PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0"/>
+		<PackageReference Include="MiNET.astar" Version="1.0.14"/>
+		<PackageReference Include="MiNET.fnbt" Version="1.0.22"/>
+		<PackageReference Include="MiNET.LevelDB" Version="1.0.37"/>
+		<PackageReference Include="NETStandard.Library" Version="2.0.3"/>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0"/>
+		<PackageReference Include="SharpAvi" Version="3.0.0"/>
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.0"/>
+		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14"/>
+		<PackageReference Include="System.Linq.Expressions" Version="4.3.0"/>
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0"/>
+		<PackageReference Include="System.Text.Json" Version="6.0.5"/>
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Remove="Net\MCPE Protocol.xml"/>
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="Net\MCPE Protocol.xml"/>
+		<None Update="Net\MCPE Protocol Documentation.tt">
+			<DependentUpon>MCPE Protocol.xml</DependentUpon>
+			<Generator>TextTemplatingFileGenerator</Generator>
+			<LastGenOutput>MCPE Protocol Documentation.md</LastGenOutput>
+		</None>
+		<None Update="Net\MCPE Protocol Documentation.md">
+			<DependentUpon>MCPE Protocol Documentation.tt</DependentUpon>
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+		</None>
+		<None Update="Net\MCPE Protocol.tt">
+			<DependentUpon>MCPE Protocol.xml</DependentUpon>
+			<Generator>TextTemplatingFileGenerator</Generator>
+			<LastGenOutput>MCPE Protocol.cs</LastGenOutput>
+		</None>
+		<Compile Update="Net\MCPE Protocol.cs">
+			<DependentUpon>MCPE Protocol.tt</DependentUpon>
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+		</Compile>
+	</ItemGroup>
+	<ItemGroup>
+		<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}"/>
+	</ItemGroup>
 </Project>

--- a/src/MiNET/MiNET/Utils/BlockPalette.cs
+++ b/src/MiNET/MiNET/Utils/BlockPalette.cs
@@ -25,8 +25,6 @@
 
 using System;
 using System.Collections.Generic;
-using fNbt;
-using Microsoft.VisualBasic.CompilerServices;
 using Newtonsoft.Json;
 
 namespace MiNET.Utils

--- a/src/MiNET/MiNET/Utils/LinqEnumerableExtensions.cs
+++ b/src/MiNET/MiNET/Utils/LinqEnumerableExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+#if NETSTANDARD
+
+namespace MiNET.Utils
+{
+	public static class LinqEnumerableExtensions
+	{
+		public static TSource MaxBy<TSource, TProperty>(this IEnumerable<TSource> source, Func<TSource, TProperty> expr)
+			=> source.OrderByDescending(expr).First();
+		
+		public static TSource MinBy<TSource, TProperty>(this IEnumerable<TSource> source, Func<TSource, TProperty> expr)
+			=> source.OrderBy(expr).First();
+	}
+}
+
+#endif

--- a/src/MiNET/MiNET/Utils/Skins/Skin.cs
+++ b/src/MiNET/MiNET/Utils/Skins/Skin.cs
@@ -25,7 +25,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing.Imaging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;

--- a/src/MiNET/MiNET/Worlds/SkyLightCalculations.cs
+++ b/src/MiNET/MiNET/Worlds/SkyLightCalculations.cs
@@ -27,7 +27,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Numerics;


### PR DESCRIPTION
Depends on MiNET.LevelDB's PR being merged + built + published (assumed a patch version bump) before this will build successfully!

Includes linq replacements for netstandard only + extra packages also for netstandard. works on my machine :P